### PR TITLE
fix: only set next version to manual if it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## actions development version
 
+- fix `draft-release` action to only use a manual version if it is provided, otherwise default to automatically determine it based on conventional commits. (#10, @kelly-sovacool)
+
 ## actions 0.1.0
 
 This is the first release of `ccbr_actions`! 🎉

--- a/src/ccbr_actions/release.py
+++ b/src/ccbr_actions/release.py
@@ -128,7 +128,7 @@ def get_release_version(
 
     If a manual version is provided, it is used regardless of the conventional commit history.
     """
-    if gh_event_name == "workflow_dispatch" or next_version_manual:
+    if next_version_manual:
         next_version = next_version_manual
         if next_version_convco and next_version_manual != next_version_convco:
             warnings.warn(

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -60,11 +60,22 @@ def test_get_changelog_lines():
 
 
 def test_get_release_version():
-    get_release_version(
-        next_version_manual=None,
-        next_version_convco="v1.10.0",
-        current_version="v1.9.10",
-    ) == "v1.10.0"
+    assert all(
+        [
+            get_release_version(
+                next_version_manual="",
+                next_version_convco="v1.10.0",
+                current_version="v1.9.10",
+            )
+            == "v1.10.0",
+            get_release_version(
+                next_version_manual="v1.10.0",
+                next_version_convco="v1.9.11",
+                current_version="v1.9.10",
+            )
+            == "v1.10.0",
+        ]
+    )
 
 
 def test_get_release_version_warning():


### PR DESCRIPTION
## Changes

Previously, it used the next manual version even if it was an empty string if the run was triggered by a workflow dispatch

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
