### PR TITLE
refactor: set update-sliding-branch to false by default

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: CCBR/actions/post-release@main
         with:
           github-token: ${{ github.token }}
+          update-sliding-branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - fix: make sure `get_latest_release_hash()` and `get_current_hash()` strip newlines in hash strings. (@kelly-sovacool)
   - this bug caused a malformed command string in `is_ancestor()`, which caused `mkdocs-mike` to fail.
-- set `update-sliding-branch` to false by default in `post-release` action. (@kelly-sovacool)
+- set `update-sliding-branch` to false by default in `post-release` action. (#18, @kelly-sovacool)
 
 ## actions 0.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## actions development version
 
 - fix: make sure `get_latest_release_hash()` and `get_current_hash()` strip newlines in hash strings. (@kelly-sovacool)
-  - this bug caused a malformed command string in `is_ancestor()`, which caused `mkdocs-mike` to fail.  
+  - this bug caused a malformed command string in `is_ancestor()`, which caused `mkdocs-mike` to fail.
+- set `update-sliding-branch` to false by default in `post-release` action. (@kelly-sovacool)
 
 ## actions 0.1.2
 

--- a/post-release/README.md
+++ b/post-release/README.md
@@ -91,5 +91,5 @@ steps:
 - `github-actor`: Username of GitHub actor for the git commit when the
   docs branch is deployed. **Required.** Default:
   `41898282+github-actions[bot]`.
-- `update-sliding-branch`: Whether to update the sliding branch to the
-  new major.minor version. Default: `true`.
+- `update-sliding-branch`: Whether to update the sliding branch
+  (major.minor) to the new patch version. Default: `false`.

--- a/post-release/action.yml
+++ b/post-release/action.yml
@@ -39,8 +39,8 @@ inputs:
     required: true
     default: "41898282+github-actions[bot]"
   update-sliding-branch:
-    description: "Whether to update the sliding branch to the new major.minor version"
-    default: "true"
+    description: "Whether to update the sliding branch (major.minor) to the new patch version"
+    default: "false"
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Changes

most of our repos don't need these branches -- they're only needed so far by CCBR/actions and CCBR/Tools so they can be listed in pyproject.toml files by only the major and minor version.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
