### PR TITLE
fix: allow docs site to build when there have been no releases

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - fix: make sure `get_latest_release_hash()` and `get_current_hash()` strip newlines in hash strings. (@kelly-sovacool)
   - this bug caused a malformed command string in `is_ancestor()`, which caused `mkdocs-mike` to fail.
 - set `update-sliding-branch` to false by default in `post-release` action. (#18, @kelly-sovacool)
+- fix bug that prevented `mkdocs-mike` from working on repos with no release. (#20, @kelly-sovacool)
 
 ## actions 0.1.2
 

--- a/src/ccbr_actions/docs.py
+++ b/src/ccbr_actions/docs.py
@@ -18,12 +18,17 @@ from .versions import (
 from .actions import set_output
 
 
-def get_docs_version():
+def get_docs_version(release_args=""):
     """
     Get correct version and alias for documentation website.
 
     Determines the appropriate version and alias for the
     documentation based on the latest release tag and the current hash.
+
+    Parameters
+    ----------
+    release_args : str, optional
+        Additional arguments to pass to the `gh release` GitHub CLI command (default is "").
 
     Returns
     -------
@@ -53,11 +58,11 @@ def get_docs_version():
     >>> get_docs_version()
     ('1.0', 'latest')
     """
-    release_tag = get_latest_release_tag().lstrip("v")
+    release_tag = get_latest_release_tag(args=release_args).lstrip("v")
     if not release_tag:
         warnings.warn("No latest release found")
 
-    release_hash = get_latest_release_hash()
+    release_hash = get_latest_release_hash(args=release_args)
     current_hash = get_current_hash()
 
     if release_hash == current_hash:

--- a/src/ccbr_actions/docs.py
+++ b/src/ccbr_actions/docs.py
@@ -64,7 +64,9 @@ def get_docs_version():
         docs_alias = "latest"
         docs_version = get_major_minor_version(release_tag)
     else:
-        if is_ancestor(ancestor=release_hash, descendant=current_hash):
+        if not release_hash or is_ancestor(
+            ancestor=release_hash, descendant=current_hash
+        ):
             docs_alias = ""
             docs_version = "dev"
         else:

--- a/src/ccbr_actions/versions.py
+++ b/src/ccbr_actions/versions.py
@@ -276,11 +276,16 @@ def get_latest_release_tag(args=""):
     return latest_release["tagName"] if latest_release else ""
 
 
-def get_latest_release_hash():
+def get_latest_release_hash(args=""):
     """
     Get the commit hash of the latest release.
 
     Uses git rev-list to get the commit hash of the latest release tag.
+
+    Parameters
+    ----------
+    args : str, optional
+        Additional arguments to pass to the GitHub CLI command (default is "").
 
     Returns
     -------
@@ -301,7 +306,7 @@ def get_latest_release_hash():
     >>> get_latest_release_hash()
     'abc123def4567890abcdef1234567890abcdef12'
     """
-    tag_name = get_latest_release_tag()
+    tag_name = get_latest_release_tag(args=args)
     tag_hash = ""
     if tag_name:
         tag_hash = shell_run(f"git rev-list -n 1 {tag_name}")

--- a/src/ccbr_actions/versions.py
+++ b/src/ccbr_actions/versions.py
@@ -273,7 +273,7 @@ def get_latest_release_tag(args=""):
     latest_release = next(
         (release for release in releases if release["isLatest"]), None
     )
-    return latest_release["tagName"]
+    return latest_release["tagName"] if latest_release else ""
 
 
 def get_latest_release_hash():
@@ -302,7 +302,9 @@ def get_latest_release_hash():
     'abc123def4567890abcdef1234567890abcdef12'
     """
     tag_name = get_latest_release_tag()
-    tag_hash = shell_run(f"git rev-list -n 1 {tag_name}")
-    if "fatal: ambiguous argument" in tag_hash:
-        raise ValueError(f"Tag {tag_name} not found in repository commit history")
+    tag_hash = ""
+    if tag_name:
+        tag_hash = shell_run(f"git rev-list -n 1 {tag_name}")
+        if "fatal: ambiguous argument" in tag_hash:
+            raise ValueError(f"Tag {tag_name} not found in repository commit history")
     return tag_hash.strip()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,5 +1,7 @@
 import os
+import pytest
 import tempfile
+import warnings
 
 from ccbr_actions.docs import (
     get_docs_version,
@@ -41,5 +43,16 @@ def test_action_markdown_io():
             "## Inputs\n" in action_md,
             "## Outputs\n" in action_md,
             "The version of the docs being deployed." in action_md,
+        ]
+    )
+
+
+def test_get_docs_version():
+    with pytest.warns(UserWarning) as record:
+        result = get_docs_version(release_args="--repo CCBR/CCBR_NextflowTemplate")
+    assert all(
+        [
+            result == ("dev", ""),
+            "No latest release found" in str(record[0].message.args[0]),
         ]
     )

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -3,6 +3,7 @@ import pytest
 from ccbr_actions.versions import (
     get_releases,
     get_latest_release_tag,
+    get_latest_release_hash,
     match_semver,
     check_version_increments_by_one,
     get_major_minor_version,
@@ -16,6 +17,15 @@ def test_get_releases():
 
 def test_get_latest_release_tag():
     assert match_semver(get_latest_release_tag(), with_leading_v=True)
+
+
+def test_get_latest_release_hash():
+    assert all(
+        [
+            len(get_latest_release_hash()) > 7,
+            get_latest_release_hash(args="--repo CCBR/CCBR_NextflowTemplate") == "",
+        ]
+    )
 
 
 def test_version_increment():
@@ -52,6 +62,9 @@ def test_version_increment_error():
     messages.append(
         "Tag v10 does not match semantic versioning guidelines." in str(exc_info.value)
     )
+    with pytest.raises(ValueError) as exc_info:
+        check_version_increments_by_one("v1", "10", with_leading_v=True)
+    messages.append("The tag does not start with 'v'." in str(exc_info.value))
     assert all(messages)
 
 


### PR DESCRIPTION
## Changes

Fix mkdocs-mike logic to not error when no releases exist

## Issues

resolves #19

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
