### PR TITLE
fix: resolve symlinks when writing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - this bug caused a malformed command string in `is_ancestor()`, which caused `mkdocs-mike` to fail.
 - set `update-sliding-branch` to false by default in `post-release` action. (#18, @kelly-sovacool)
 - fix bug that prevented `mkdocs-mike` from working on repos with no release. (#20, @kelly-sovacool)
+- fix: resolve symlinks when writing files. (#23, @kelly-sovacool)
 
 ## actions 0.1.2
 

--- a/src/ccbr_actions/actions.py
+++ b/src/ccbr_actions/actions.py
@@ -19,6 +19,7 @@ import os
 import requests
 import uuid
 
+from .util import path_resolve
 from .versions import get_latest_release_tag
 
 
@@ -74,7 +75,7 @@ def use_github_action(name, ref=None, url=None, save_as=None, repo="CCBR/actions
 
     response = requests.get(url)
     if response.status_code == 200:
-        with open(save_as, "w") as outfile:
+        with open(path_resolve(save_as), "w") as outfile:
             outfile.write(response.text)
     else:
         raise ValueError(

--- a/src/ccbr_actions/citation.py
+++ b/src/ccbr_actions/citation.py
@@ -2,7 +2,7 @@ from cffconvert.cli.create_citation import create_citation
 from cffconvert.cli.validate_or_write_output import validate_or_write_output
 import yaml
 
-from .util import date_today
+from .util import date_today, path_resolve
 
 
 def print_citation(
@@ -29,5 +29,5 @@ def update_citation(
     if debug:
         print(citation_yaml)
     else:
-        with open(citation_file, "w") as outfile:
+        with open(path_resolve(citation_file), "w") as outfile:
             outfile.write(citation_yaml)

--- a/src/ccbr_actions/util.py
+++ b/src/ccbr_actions/util.py
@@ -3,6 +3,7 @@ Utility functions for the package
 """
 
 import datetime
+import pathlib
 from ccbr_tools.shell import shell_run
 
 
@@ -12,3 +13,17 @@ def date_today():
 
 def precommit_run(args):
     return shell_run(f"pre-commit run {args}", check=False)
+
+
+def path_resolve(filepath):
+    """
+    Resolves the given filepath to an absolute path.
+
+    Args:
+        filepath (str): The path to be resolved.
+
+    Returns:
+        pathlib.Path: The resolved absolute path.
+
+    """
+    return pathlib.Path(filepath).resolve()

--- a/tests/data/file_ln
+++ b/tests/data/file_ln
@@ -1,0 +1,1 @@
+file.txt

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,9 @@
-from ccbr_actions.util import precommit_run
+from ccbr_actions.util import date_today, precommit_run, path_resolve
 
 
 def test_precommit():
     assert "usage: pre-commit run [-h]" in precommit_run("--help")
+
+
+def test_path_resolve_symlink():
+    assert str(path_resolve("tests/data/file_ln")).endswith("tests/data/file.txt")


### PR DESCRIPTION
## Changes

use pathlib to resolve files when opening for writing, in case they might be symlinks

this is the case for VERSION and CITATION.cff in this repo

## Issues

fixes #21

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
