### PR TITLE
fix build-docker to open & merge PR for protected branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   - `label-issue-repo-name` - Label issues & PRs with the repository name
   - `add-issue-label-list` - Update issue description with a list of issues of a given label
   - `update-cff-R` - For R packages: update the CITATION.cff file based on the DESCRIPTION file.
-  - `build-docker` - Build docker containers for [CCBR/Dockers2](https://github.com/CCBR/dockers2). (#31, @kelly-sovacool)
+  - `build-docker` - Build docker containers for [CCBR/Dockers2](https://github.com/CCBR/dockers2). (#31, #33, @kelly-sovacool)
 - minor documentation improvements.
 
 ## actions 0.1.3

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -32,7 +32,7 @@ steps:
       dockerfile: Dockerfile.v1
       dockerhub-namespace: ${{ secrets.DOCKERHUB_NAMESPACE }}
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       suffix: dev
       push: true
       ccbr-actions-version: v0.2
@@ -72,6 +72,8 @@ files change, see
   `41898282+github-actions[bot]`.
 - `github-token`: GitHub Actions token (e.g. github.token) .
   **Required.**
+- `print-versions`: Whether to print tool versions in the container for
+  the README file using `json-file` . Default: `True`.
 - `json-file`: path to JSON file for printing tool versions . Default:
   `scripts/tool_version_commands.json`.
 - `gh-merge-args`: arguments for `gh pr merge` . Default: `-ds --admin`.

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -2,27 +2,25 @@
 
 **`build-docker`** - Build a docker container using CCBR guidelines
 
-This action is designed to be used to build Docker containers according
-to the CCBR format as used in
-[CCBR/dockers2](https://github.com/CCBR/Dockers2).
+This action is designed to build Docker containers according to the
+format used in [CCBR/dockers2](https://github.com/CCBR/Dockers2).
 
 This action:
 
 - Logs in to DockerHub if the ‘push’ input is set to ‘true’.
 - Prepares build-time variables by running a custom script.
-- Checks variables and creates a temporary README file with build
-  details.
+- Checks variables and creates a README file with build details in the
+  same directory as the dockerfile.
 - Builds and optionally pushes the Docker image using the
   docker/build-push-action.
 - Lists Docker images on the runner.
-- Updates the DockerHub description with the contents of the temporary
-  README file if the image was successfully pushed.
+- Updates the DockerHub description with the contents of the README file
+  if the image was successfully pushed.
+- Opens and merges a PR with the updates to the README file.
 
 ## Usage
 
 ### Basic example
-
-[build-docker-manual.yml](/examples/build-docker-manual.yml)
 
 ```yaml
 steps:
@@ -31,16 +29,20 @@ steps:
       fetch-depth: 0
   - uses: CCBR/actions/build-docker@main
     with:
-      dockerfile: ${{ github.event.inputs.dockerfile }}
-      dockerhub-namespace: ${{ github.event.inputs.dockerhub-namespace }}
-      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME_VK }}
-      dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN_VK }}
-      suffix: ${{ github.event.inputs.suffix }}
-      push: ${{ github.event.inputs.push }}
-      ccbr-actions-version: ${{ github.event.inputs.ccbr-actions-version }}
+      dockerfile: Dockerfile.v1
+      dockerhub-namespace: ${{ secrets.DOCKERHUB_NAMESPACE }}
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN }}
+      suffix: dev
+      push: true
+      ccbr-actions-version: v0.2
       github-token: ${{ github.token }}
       github-actor: ${{ github.actor }}
 ```
+
+For an example to manually trigger the workflow for a single docker
+container, see
+[build-docker-manual.yml](/examples/build-docker-manual.yml).
 
 For an advanced example to automatically build docker containers when
 files change, see

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -74,6 +74,8 @@ files change, see
   **Required.**
 - `print-versions`: Whether to print tool versions in the container for
   the README file using `json-file` . Default: `True`.
-- `json-file`: path to JSON file for printing tool versions . Default:
+- `json-file`: Relative path to JSON file for printing tool versions. If
+  not provided and print-versions is true, a default JSON file in
+  ccbr_actions will be used. . Default:
   `scripts/tool_version_commands.json`.
 - `gh-merge-args`: arguments for `gh pr merge` . Default: `-ds --admin`.

--- a/build-docker/README.qmd
+++ b/build-docker/README.qmd
@@ -41,7 +41,7 @@ steps:
       dockerfile: Dockerfile.v1
       dockerhub-namespace: ${{ secrets.DOCKERHUB_NAMESPACE }}
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-      dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN }}
+      dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
       suffix: dev
       push: true
       ccbr-actions-version: v0.2

--- a/build-docker/README.qmd
+++ b/build-docker/README.qmd
@@ -14,23 +14,22 @@ action = ccbr_actions.docs.parse_action_yaml('action.yml')
 print(ccbr_actions.docs.action_markdown_desc(action))
 ```
 
-This action is designed to be used to build Docker containers according to
-the CCBR format as used in [CCBR/dockers2](https://github.com/CCBR/Dockers2).
+This action is designed to build Docker containers according to
+the format used in [CCBR/dockers2](https://github.com/CCBR/Dockers2).
 
 This action:
 
   - Logs in to DockerHub if the 'push' input is set to 'true'.
   - Prepares build-time variables by running a custom script.
-  - Checks variables and creates a temporary README file with build details.
+  - Checks variables and creates a README file with build details in the same directory as the dockerfile.
   - Builds and optionally pushes the Docker image using the docker/build-push-action.
   - Lists Docker images on the runner.
-  - Updates the DockerHub description with the contents of the temporary README file if the image was successfully pushed.
+  - Updates the DockerHub description with the contents of the README file if the image was successfully pushed.
+  - Opens and merges a PR with the updates to the README file.
 
 ## Usage
 
 ### Basic example
-
-[build-docker-manual.yml](/examples/build-docker-manual.yml)
 
 ```yaml
 steps:
@@ -39,16 +38,19 @@ steps:
         fetch-depth: 0
   - uses: CCBR/actions/build-docker@main
     with:
-      dockerfile: ${{ github.event.inputs.dockerfile }}
-      dockerhub-namespace: ${{ github.event.inputs.dockerhub-namespace }}
-      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME_VK }}
-      dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN_VK }}
-      suffix: ${{ github.event.inputs.suffix }}
-      push: ${{ github.event.inputs.push }}
-      ccbr-actions-version: ${{ github.event.inputs.ccbr-actions-version }}
+      dockerfile: Dockerfile.v1
+      dockerhub-namespace: ${{ secrets.DOCKERHUB_NAMESPACE }}
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN }}
+      suffix: dev
+      push: true
+      ccbr-actions-version: v0.2
       github-token: ${{ github.token }}
       github-actor: ${{ github.actor }}
 ```
+
+For an example to manually trigger the workflow for a single docker container,
+see [build-docker-manual.yml](/examples/build-docker-manual.yml).
 
 For an advanced example to automatically build docker containers when files
 change, see [build-docker-auto.yml](/examples/build-docker-auto.yml).

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -63,6 +63,8 @@ runs:
       run: |
         git config --local user.email "${{ inputs.github-actor }}@users.noreply.github.com"
         git config --local user.name "${{ inputs.github-actor }}"
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
 
     - uses: actions/setup-python@v5
       with:
@@ -145,6 +147,7 @@ runs:
       shell: bash
       if: ${{ (inputs.push == 'true') && (steps.build_and_push.outcome == 'success') }}
       run: |
+        echo " actor: ${{ inputs.github-actor }}"
         git add ${{ env.MDFILE }}
         git commit -m "docs: update readme for ${{ env.DOCKERFILE }}"
         git push https://x-access-token:${{ inputs.github-token }}@github.com/${{ github.repository }}.git HEAD:dev

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -162,8 +162,9 @@ runs:
     - name: Create Pull Request
       id: create-pr
       uses: peter-evans/create-pull-request@v7
+      if: ${{ steps.update_dockerhub_description.outcome == 'success' }}
       with:
-        token: ${{ github.token }} #${{ secrets.PAT_PROTECTEDBRANCH }}
+        token: ${{ github.token }}
         add-paths: ${{ env.MDFILE }}
         commit-message: "docs: 🤖 update readme for ${{ env.DOCKERFILE }}"
         author: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -155,7 +155,7 @@ runs:
         commit-message: "docs: 🤖 update readme for ${{ env.DOCKERFILE }}"
         author: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"
         committer: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"
-        branch: "pr/${{ env.DOCKERFILE }}"
+        branch: "auto-pr/${{ env.DOCKERFILE }}"
         title: "docs: 🤖 update readme for ${{ env.IMAGENAME }}"
 
     - name: Approve PR
@@ -163,7 +163,7 @@ runs:
       if: ${{ (steps.create-pr.outputs.pull-request-operation == 'created') || (steps.create-pr.outputs.pull-request-operation == 'updated') }}
       run: |
         echo $PR
-        gh pr approve ${PR}
+        gh pr --approve ${PR}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         args: ${{ inputs.gh-merge-args }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -58,7 +58,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-
     - name: Confirm Actor
       shell: bash
       run: |
@@ -154,9 +153,9 @@ runs:
       shell: bash
       if: ${{ (inputs.push == 'true') && (steps.build_and_push.outcome == 'success') }}
       run: |
-        echo " actor: ${{ inputs.github-actor }}"
+        git pull --ff-only
         git add ${{ env.MDFILE }}
         git commit -m "docs: update readme for ${{ env.DOCKERFILE }}"
-        git push https://x-access-token:${{ env.PAT }}@github.com/${{ github.repository }}.git HEAD:dev
+        git push https://x-access-token:${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:dev
       env:
-        PAT: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -156,6 +156,6 @@ runs:
         git pull --ff-only
         git add ${{ env.MDFILE }}
         git commit -m "docs: update readme for ${{ env.DOCKERFILE }}"
-        git push https://x-access-token:${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:dev
+        git push
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -160,10 +160,9 @@ runs:
 
     - name: Approve PR
       shell: bash
-      if: ${{ (steps.create-pr.outputs.pull-request-operation == 'created') || (steps.create-pr.outputs.pull-request-operation == 'updated') }}
+      if: ${{ (steps.create-pr.outputs.pull-request-number != '') && (steps.create-pr.outputs.pull-request-operation == 'created') || (steps.create-pr.outputs.pull-request-operation == 'updated') }}
       run: |
-        echo $PR
-        gh pr --approve ${PR}
+        gh pr merge ${args} ${PR}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         args: ${{ inputs.gh-merge-args }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -75,7 +75,7 @@ runs:
       with:
         python-version: "${{ inputs.python-version }}"
 
-    - name: Install
+    - name: Install CCBR/actions
       shell: bash
       run: pip install --upgrade pip git+https://github.com/CCBR/actions.git@${{ inputs.ccbr-actions-version }}
 
@@ -137,6 +137,7 @@ runs:
       id: run_script_in_container
       if: ${{ inputs.print-versions == 'true' }}
       run: |
+        set -euo pipefail
         SCRIPT=$(which print_versions.py)
         echo $SCRIPT
         cp $SCRIPT ${{ github.workspace }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -181,3 +181,9 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         args: ${{ inputs.gh-merge-args }}
         PR: ${{ steps.create-pr.outputs.pull-request-number }}
+
+    - name: upload readme file on failure
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        path: ${{ env.MDFILE }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -60,6 +60,7 @@ runs:
   steps:
 
     - name: Confirm Actor
+      shell: bash
       run: |
         echo "This action was triggered by the actor: ${{ github.actor }}"
         echo "Original actor passed from primary workflow: ${{ inputs.github-actor }}"

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -179,6 +179,7 @@ runs:
 
     - name: Approve PR
       shell: bash
+      id: approve-pr
       if: ${{ (steps.create-pr.outputs.pull-request-number != '') && (steps.create-pr.outputs.pull-request-operation == 'created') || (steps.create-pr.outputs.pull-request-operation == 'updated') }}
       run: |
         gh pr merge ${args} ${PR}
@@ -187,8 +188,8 @@ runs:
         args: ${{ inputs.gh-merge-args }}
         PR: ${{ steps.create-pr.outputs.pull-request-number }}
 
-    - name: upload readme file on failure
+    - name: upload readme file
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: failure() || ${{ steps.approve-pr.outcome != 'success'}}
       with:
         path: ${{ env.MDFILE }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -61,7 +61,7 @@ inputs:
   gh-merge-args:
     description: |
       arguments for `gh pr merge`
-    default: "-s --admin"
+    default: "-ds --admin"
 
 runs:
   using: "composite"
@@ -160,6 +160,7 @@ runs:
 
     - name: Approve PR
       shell: bash
+      if: ${{ (steps.create-pr.outputs.pull-request-operation == 'created') || (steps.create-pr.outputs.pull-request-operation == 'updated') }}
       run: |
         gh pr merge ${args} ${PR}
       env:

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -62,14 +62,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: git config
-      shell: bash
-      run: |
-        git config --local user.email "${{ inputs.github-actor }}@users.noreply.github.com"
-        git config --local user.name "${{ inputs.github-actor }}"
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-
     - uses: actions/setup-python@v5
       with:
         python-version: "${{ inputs.python-version }}"
@@ -150,13 +142,21 @@ runs:
         repository: ${{ inputs.dockerhub-namespace }}/${{ env.REPONAME }}
         readme-filepath: ${{ env.MDFILE }}
 
-    - name: Commit and Push Markdown File
-      shell: bash
-      if: ${{ (inputs.push == 'true') && (steps.build_and_push.outcome == 'success') }}
+    - name: Create Pull Request
+      id: create-pr
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ inputs.github-token }} #${{ secrets.PAT_PROTECTEDBRANCH }}
+        add-paths: ${{ env.MDFILE }}
+        commit-message: "docs: 🤖 update readme for ${{ env.DOCKERFILE }}"
+        author: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"
+        committer: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"
+        branch: "pr/${{ env.IMAGENAME }}"
+        title: "docs: 🤖 update readme for ${{ env.IMAGENAME }}"
+
+    - name: Approve PR
       run: |
-        git pull --ff-only
-        git add ${{ env.MDFILE }}
-        git commit -m "docs: 🤖 update readme for ${{ env.DOCKERFILE }}"
-        git push
+        gh pr merge -r --admin ${PR}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        PR: ${{ steps.create-pr.outputs.pull-request-number }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -58,12 +58,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Confirm Actor
-      shell: bash
-      run: |
-        echo "This action was triggered by the actor: XX${{ github.actor }}XX"
-        echo "Original actor passed from primary workflow: XX${{ inputs.github-actor }}XX"
-
     - name: git config
       shell: bash
       run: |
@@ -155,7 +149,7 @@ runs:
       run: |
         git pull --ff-only
         git add ${{ env.MDFILE }}
-        git commit -m "docs: update readme for ${{ env.DOCKERFILE }}"
+        git commit -m "docs: 🤖 update readme for ${{ env.DOCKERFILE }}"
         git push
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -157,6 +157,6 @@ runs:
         echo " actor: ${{ inputs.github-actor }}"
         git add ${{ env.MDFILE }}
         git commit -m "docs: update readme for ${{ env.DOCKERFILE }}"
-        git push https://x-access-token:${{ inputs.github-token }}@github.com/${{ github.repository }}.git HEAD:dev
+        git push https://x-access-token:${{ env.PAT }}@github.com/${{ github.repository }}.git HEAD:dev
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        PAT: ${{ inputs.github-token }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: |
       path to JSON file for printing tool versions
     default: "scripts/tool_version_commands.json"
+  gh-merge-args:
+    description: |
+      arguments for `gh pr merge`
+    default: "-s --admin"
 
 runs:
   using: "composite"
@@ -157,7 +161,8 @@ runs:
     - name: Approve PR
       shell: bash
       run: |
-        gh pr merge -r --admin ${PR}
+        gh pr merge ${args} ${PR}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        args: ${{ inputs.gh-merge-args }}
         PR: ${{ steps.create-pr.outputs.pull-request-number }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -135,9 +135,10 @@ runs:
       shell: bash
       id: run_script_in_container
       run: |
+        print_versions=$(which print_versions.py)
         docker run --rm -v "${{ github.workspace }}:/ws" ${{ env.IMAGENAME }} \
-          bash -c "python3 print_versions.py --json /ws/${{ inputs.json-file }}" \
-          >> ${{ env.MDFILE }}
+          python3 /ws/scripts/print_versions.py --json /ws/${{ inputs.json-file }} --output /ws/${{ env.MDFILE }}
+      # TODO move print versions script
 
     - name: Update Docker Hub Description
       id: update_dockerhub_description

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -162,7 +162,8 @@ runs:
       shell: bash
       if: ${{ (steps.create-pr.outputs.pull-request-operation == 'created') || (steps.create-pr.outputs.pull-request-operation == 'updated') }}
       run: |
-        gh pr merge ${args} ${PR}
+        echo $PR
+        gh pr approve ${PR}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         args: ${{ inputs.gh-merge-args }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: |
       GitHub Actions token (e.g. github.token)
     required: true
+  json-file:
+    description: |
+      path to JSON file for printing tool versions
+    default: "scripts/tool_version_commands.json"
 
 runs:
   using: "composite"
@@ -131,7 +135,9 @@ runs:
       shell: bash
       id: run_script_in_container
       run: |
-        docker run --rm -v "${{ github.workspace }}:/ws" ${{ env.IMAGENAME }} bash -c "python3 print_versions.py --json /ws/scripts/tool_version_commands.json" >> ${{ env.MDFILE }}
+        docker run --rm -v "${{ github.workspace }}:/ws" ${{ env.IMAGENAME }} \
+          bash -c "python3 print_versions.py --json /ws/${{ inputs.json-file }}" \
+          >> ${{ env.MDFILE }}
 
     - name: Update Docker Hub Description
       id: update_dockerhub_description

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -131,7 +131,7 @@ runs:
       shell: bash
       id: run_script_in_container
       run: |
-        docker run --rm -v "${{ github.workspace }}:/ws" ${{ env.IMAGENAME }} bash -c "python3 /ws/scripts/print_versions.py --json /ws/scripts/tool_version_commands.json" >> ${{ env.MDFILE }}
+        docker run --rm -v "${{ github.workspace }}:/ws" ${{ env.IMAGENAME }} bash -c "python3 print_versions.py --json /ws/scripts/tool_version_commands.json" >> ${{ env.MDFILE }}
 
     - name: Update Docker Hub Description
       id: update_dockerhub_description

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -155,6 +155,7 @@ runs:
         title: "docs: 🤖 update readme for ${{ env.IMAGENAME }}"
 
     - name: Approve PR
+      shell: bash
       run: |
         gh pr merge -r --admin ${PR}
       env:

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -138,13 +138,17 @@ runs:
       if: ${{ inputs.print-versions == 'true' }}
       run: |
         SCRIPT=$(which print_versions.py)
+        echo $SCRIPT
         cp $SCRIPT ${{ github.workspace }}
+
         if [ -f ${{ inputs.json-file }} ]; then
           JSON=${{ inputs.json-file }}
         else
-          cp $(python -c 'import ccbr_actions.data; print(ccbr_actions.data.get_file_path("tool_version_commands.json"))') ${{ github.workspace }}
+          json_src=$(python -c 'import ccbr_actions.data; print(ccbr_actions.data.get_file_path("tool_version_commands.json"))')
+          cp $json_src ${{ github.workspace }}
           JSON=tool_version_commands.json
         fi
+        echo $JSON
 
         docker run --rm -v "${{ github.workspace }}:/ws" ${{ env.IMAGENAME }} \
           python3 /ws/print_versions.py --json /ws/${JSON} --output /ws/${{ env.MDFILE }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -58,6 +58,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+
+    - name: Confirm Actor
+      run: |
+        echo "This action was triggered by the actor: ${{ github.actor }}"
+        echo "Original actor passed from primary workflow: ${{ inputs.github-actor }}"
+
     - name: git config
       shell: bash
       run: |

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -60,7 +60,8 @@ inputs:
     default: true
   json-file:
     description: |
-      path to JSON file for printing tool versions
+      Relative path to JSON file for printing tool versions.
+      If not provided and print-versions is true, a default JSON file in ccbr_actions will be used.
     default: "scripts/tool_version_commands.json"
   gh-merge-args:
     description: |
@@ -138,8 +139,15 @@ runs:
       run: |
         SCRIPT=$(which print_versions.py)
         cp $SCRIPT ${{ github.workspace }}
+        if [ -f ${{ inputs.json-file }} ]; then
+          JSON=${{ inputs.json-file }}
+        else
+          cp $(python -c 'import ccbr_actions.data; print(ccbr_actions.data.get_file_path("tool_version_commands.json"))') ${{ github.workspace }}
+          JSON=tool_version_commands.json
+        fi
+
         docker run --rm -v "${{ github.workspace }}:/ws" ${{ env.IMAGENAME }} \
-          python3 /ws/print_versions.py --json /ws/${{ inputs.json-file }} --output /ws/${{ env.MDFILE }}
+          python3 /ws/print_versions.py --json /ws/${JSON} --output /ws/${{ env.MDFILE }}
 
     - name: Update Docker Hub Description
       id: update_dockerhub_description

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -151,7 +151,7 @@ runs:
         commit-message: "docs: 🤖 update readme for ${{ env.DOCKERFILE }}"
         author: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"
         committer: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"
-        branch: "pr/${{ env.IMAGENAME }}"
+        branch: "pr/${{ env.DOCKERFILE }}"
         title: "docs: 🤖 update readme for ${{ env.IMAGENAME }}"
 
     - name: Approve PR

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: |
       GitHub Actions token (e.g. github.token)
     required: true
+  print-versions:
+    description: |
+      Whether to print tool versions in the container for the README file using `json-file`
+    default: true
   json-file:
     description: |
       path to JSON file for printing tool versions
@@ -130,11 +134,12 @@ runs:
     - name: Run print_versions.py inside Docker container
       shell: bash
       id: run_script_in_container
+      if: ${{ inputs.print-versions == 'true' }}
       run: |
-        print_versions=$(which print_versions.py)
+        SCRIPT=$(which print_versions.py)
+        cp $SCRIPT ${{ github.workspace }}
         docker run --rm -v "${{ github.workspace }}:/ws" ${{ env.IMAGENAME }} \
-          python3 /ws/scripts/print_versions.py --json /ws/${{ inputs.json-file }} --output /ws/${{ env.MDFILE }}
-      # TODO move print versions script
+          python3 /ws/print_versions.py --json /ws/${{ inputs.json-file }} --output /ws/${{ env.MDFILE }}
 
     - name: Update Docker Hub Description
       id: update_dockerhub_description

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -199,5 +199,5 @@ runs:
       uses: actions/upload-artifact@v4
       if: failure() || ${{ steps.approve-pr.outcome != 'success'}}
       with:
-        name: ${{ env.MDFILE }}
+        name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.MDFILE }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -146,7 +146,7 @@ runs:
       id: create-pr
       uses: peter-evans/create-pull-request@v7
       with:
-        token: ${{ inputs.github-token }} #${{ secrets.PAT_PROTECTEDBRANCH }}
+        token: ${{ github.token }} #${{ secrets.PAT_PROTECTEDBRANCH }}
         add-paths: ${{ env.MDFILE }}
         commit-message: "docs: 🤖 update readme for ${{ env.DOCKERFILE }}"
         author: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -133,7 +133,7 @@ runs:
 
     - name: Update Docker Hub Description
       id: update_dockerhub_description
-      if: ${{ (github.event.inputs.push == 'true') && (steps.build_and_push.outcome == 'success') }}
+      if: ${{ (inputs.push == 'true') && (steps.build_and_push.outcome == 'success') }}
       uses: peter-evans/dockerhub-description@v4
       with:
         username: ${{ inputs.dockerhub-username }}
@@ -143,7 +143,7 @@ runs:
 
     - name: Commit and Push Markdown File
       shell: bash
-      if: ${{ (github.event.inputs.push == 'true') && (steps.build_and_push.outcome == 'success') }}
+      if: ${{ (inputs.push == 'true') && (steps.build_and_push.outcome == 'success') }}
       run: |
         git add ${{ env.MDFILE }}
         git commit -m "docs: update readme for ${{ env.DOCKERFILE }}"

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -36,34 +36,41 @@ inputs:
     required: true
     default: false
   ccbr-actions-version:
+    type: string
     description: |
       The version of ccbr_actions to use
     required: true
     default: "main"
   python-version:
+    type: string
     description: |
       The version of Python to install
     required: true
     default: "3.11"
   github-actor:
+    type: string
     description: |
       Username of GitHub actor for the git commit when the README is updated
     required: true
     default: "41898282+github-actions[bot]"
   github-token:
+    type: string
     description: |
       GitHub Actions token (e.g. github.token)
     required: true
   print-versions:
+    type: boolean
     description: |
       Whether to print tool versions in the container for the README file using `json-file`
     default: true
   json-file:
+    type: string
     description: |
       Relative path to JSON file for printing tool versions.
       If not provided and print-versions is true, a default JSON file in ccbr_actions will be used.
     default: "scripts/tool_version_commands.json"
   gh-merge-args:
+    type: string
     description: |
       arguments for `gh pr merge`
     default: "-ds --admin"

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -147,6 +147,6 @@ runs:
       run: |
         git add ${{ env.MDFILE }}
         git commit -m "docs: update readme for ${{ env.DOCKERFILE }}"
-        git push
+        git push https://x-access-token:${{ inputs.github-token }}@github.com/${{ github.repository }}.git HEAD:dev
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -62,8 +62,8 @@ runs:
     - name: Confirm Actor
       shell: bash
       run: |
-        echo "This action was triggered by the actor: ${{ github.actor }}"
-        echo "Original actor passed from primary workflow: ${{ inputs.github-actor }}"
+        echo "This action was triggered by the actor: XX${{ github.actor }}XX"
+        echo "Original actor passed from primary workflow: XX${{ inputs.github-actor }}XX"
 
     - name: git config
       shell: bash

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -199,4 +199,5 @@ runs:
       uses: actions/upload-artifact@v4
       if: failure() || ${{ steps.approve-pr.outcome != 'success'}}
       with:
+        name: ${{ env.MDFILE }}
         path: ${{ env.MDFILE }}

--- a/examples/build-docker-auto.yml
+++ b/examples/build-docker-auto.yml
@@ -35,6 +35,11 @@ on:
 
 env:
   suffix: ${{ github.base_ref == 'main' && github.event_name == 'pull_request' && 'main' || github.base_ref == 'dev' && github.event_name == 'pull_request' && 'dev' || 'feat' }}
+  GITHUB_TOKEN: ${{ secrets.PAT_PROTECTEDBRANCH }}
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   get-files:
@@ -45,12 +50,14 @@ jobs:
       - name: Checkout repository
         id: checkout
         uses: actions/checkout@v4
+
       - id: changed-files
         name: Check changed files
         uses: knu/changed-files@v1
         with:
           paths: |
             **/Dockerfile.*
+
       - name: Show changed files
         id: matrix
         run: |
@@ -62,11 +69,22 @@ jobs:
     strategy:
       matrix:
         file: "${{ fromJson(needs.get-files.outputs.json) }}"
+      max-parallel: 1
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        id: checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        name: "checkout PR ${{ github.head_ref }}"
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref }} # branch name of PR
+
+      - uses: actions/checkout@v4
+        name: "checkout push ${{ github.ref_name }}"
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }} # branch name of push
 
       - uses: CCBR/actions/build-docker@main
         with:
@@ -76,5 +94,6 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN_VK }}
           suffix: ${{ env.suffix }}
           push: true
-          github-token: ${{ github.token }}
-          github-actor: ${{ github.actor }}
+          github-token: ${{ secrets.PAT_PROTECTEDBRANCH }}
+          ccbr-actions-version: main
+          json-file: "scripts/tool_version_commands.json"

--- a/examples/build-docker-auto.yml
+++ b/examples/build-docker-auto.yml
@@ -66,6 +66,8 @@ jobs:
       matrix:
         file: "${{ fromJson(needs.get-files.outputs.json) }}"
       max-parallel: 1
+      fail-fast: false
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/examples/build-docker-auto.yml
+++ b/examples/build-docker-auto.yml
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_name }} # branch name of push
 
-      - uses: CCBR/actions/build-docker@main
+      - uses: CCBR/actions/build-docker@v0.2
         with:
           dockerfile: ${{ matrix.file }}
           dockerhub-namespace: nciccbr
@@ -93,6 +93,6 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN_VK }}
           suffix: ${{ env.suffix }}
           push: true
-          ccbr-actions-version: main
+          ccbr-actions-version: v0.2
           github-token: ${{ secrets.PAT_PROTECTEDBRANCH }}
           json-file: "scripts/tool_version_commands.json"

--- a/examples/build-docker-auto.yml
+++ b/examples/build-docker-auto.yml
@@ -37,10 +37,6 @@ env:
   suffix: ${{ github.base_ref == 'main' && github.event_name == 'pull_request' && 'main' || github.base_ref == 'dev' && github.event_name == 'pull_request' && 'dev' || 'feat' }}
   GITHUB_TOKEN: ${{ secrets.PAT_PROTECTEDBRANCH }}
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   get-files:
     runs-on: ubuntu-latest
@@ -71,6 +67,9 @@ jobs:
         file: "${{ fromJson(needs.get-files.outputs.json) }}"
       max-parallel: 1
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         name: "checkout PR ${{ github.head_ref }}"
@@ -94,6 +93,6 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKERHUBRW_TOKEN_VK }}
           suffix: ${{ env.suffix }}
           push: true
-          github-token: ${{ secrets.PAT_PROTECTEDBRANCH }}
           ccbr-actions-version: main
+          github-token: ${{ secrets.PAT_PROTECTEDBRANCH }}
           json-file: "scripts/tool_version_commands.json"

--- a/examples/build-docker-manual.yml
+++ b/examples/build-docker-manual.yml
@@ -47,13 +47,12 @@ on:
         required: true
         default: "main"
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   build-docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         id: checkout
@@ -68,5 +67,5 @@ jobs:
           suffix: ${{ github.event.inputs.suffix }}
           push: ${{ github.event.inputs.push }}
           ccbr-actions-version: ${{ github.event.inputs.ccbr-actions-version }}
-          github-token: ${{ secrets.PAT_PROTECTEDBRANCH }}
+          github-token: ${{ github.token }}
           json-file: "scripts/tool_version_commands.json"

--- a/examples/build-docker-manual.yml
+++ b/examples/build-docker-manual.yml
@@ -47,6 +47,10 @@ on:
         required: true
         default: "main"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build-docker:
     runs-on: ubuntu-latest
@@ -64,5 +68,5 @@ jobs:
           suffix: ${{ github.event.inputs.suffix }}
           push: ${{ github.event.inputs.push }}
           ccbr-actions-version: ${{ github.event.inputs.ccbr-actions-version }}
-          github-token: ${{ github.token }}
-          github-actor: ${{ github.actor }}
+          github-token: ${{ secrets.PAT_PROTECTEDBRANCH }}
+          json-file: "scripts/tool_version_commands.json"

--- a/examples/build-docker-manual.yml
+++ b/examples/build-docker-manual.yml
@@ -45,7 +45,7 @@ on:
       ccbr-actions-version:
         description: "The version of ccbr_actions to use"
         required: true
-        default: "main"
+        default: "v0.2"
 
 jobs:
   build-docker:
@@ -58,7 +58,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - uses: CCBR/actions/build-docker@main
+      - uses: CCBR/actions/build-docker@v0.2
         with:
           dockerfile: ${{ github.event.inputs.dockerfile }}
           dockerhub-namespace: ${{ github.event.inputs.dockerhub-namespace }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,5 +87,6 @@ readme = {file = "README.md"}
 
 [tool.setuptools]
 script-files = [
-    "scripts/prepare_docker_build_variables.sh"
+    "scripts/prepare_docker_build_variables.sh",
+    "scripts/print_versions.py"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ override_SS05 = [  # override SS05 to allow docstrings starting with these words
 
 [tool.setuptools.package-data]
 "*" = ["LICENSE", "CHANGELOG.md", "lib/**", "examples/**"]
+"ccbr_actions.data" = ["src/ccbr_actions/data/*"]
 
 [tool.setuptools.dynamic]
 version = {file = "src/ccbr_actions/VERSION"}

--- a/scripts/prepare_docker_build_variables.sh
+++ b/scripts/prepare_docker_build_variables.sh
@@ -57,6 +57,7 @@ else
 fi
 imagename="${dockerhub_account}/${reponame}:${tag}"
 mdfile="${dn_dockerfile}/${tag}.README.md"
+artifact_name=$(echo $mdfile | sed 's|/|_|g')
 
 # Output each variable to $GITHUB_ENV to pass it to the next steps
 echo "DOCKERFILE=$dockerfile" >> $GITHUB_ENV
@@ -66,3 +67,4 @@ echo "BUILD_DATE=$dt" >> $GITHUB_ENV
 echo "BUILD_TAG=$tag" >> $GITHUB_ENV
 echo "REPONAME=$reponame" >> $GITHUB_ENV
 echo "MDFILE=$mdfile" >> $GITHUB_ENV
+echo "ARTIFACT_NAME=$artifact_name" >> $GITHUB_ENV

--- a/scripts/print_versions.py
+++ b/scripts/print_versions.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+import json
+import subprocess
+import argparse
+import shutil
+
+# Set up argument parsing
+parser = argparse.ArgumentParser(
+    description="Generate a Markdown table of command versions from a JSON file."
+)
+parser.add_argument(
+    "--json",
+    required=True,
+    type=str,
+    help="Path to the JSON file containing commands and their version commands.",
+)
+args = parser.parse_args()
+
+# Load JSON data
+with open(args.json, "r") as file:
+    commands = json.load(file)
+
+# Prepare table header
+print("")
+print("| Tool | Version |")
+print("|---------|---------|")
+
+# Run each command and capture output
+for command_name, version_command in commands.items():
+    if shutil.which(command_name):
+        try:
+            # Run the command and capture its output
+            result = subprocess.run(
+                version_command, shell=True, check=True, text=True, capture_output=True
+            )
+            version_info = (
+                result.stdout.strip() if result.stdout else result.stderr.strip()
+            )
+            version_info = (
+                version_info.strip()
+                .replace('"', "")
+                .replace("'", "")
+                .replace("(", "")
+                .replace(")", "")
+            )
+            version_info = version_info.strip() or "VERSIONUNKNOWN"
+        except subprocess.CalledProcessError:
+            # If the command doesn't exist, handle the exception
+            version_info = "NOTINDOCKER"
+    else:
+        version_info = "NOTINDOCKER"
+    # Print in Markdown table format
+    print(f"| {command_name} | {version_info} |")
+
+print("")

--- a/scripts/print_versions.py
+++ b/scripts/print_versions.py
@@ -14,42 +14,67 @@ parser.add_argument(
     type=str,
     help="Path to the JSON file containing commands and their version commands.",
 )
-args = parser.parse_args()
+parser.add_argument(
+    "--output",
+    required=False,
+    type=str,
+    help="Output file path. If not specified, output will be printed to stdout.",
+)
 
-# Load JSON data
-with open(args.json, "r") as file:
-    commands = json.load(file)
 
-# Prepare table header
-print("")
-print("| Tool | Version |")
-print("|---------|---------|")
+def create_table(args):
+    # Load JSON data
+    with open(args.json, "r") as file:
+        commands = json.load(file)
 
-# Run each command and capture output
-for command_name, version_command in commands.items():
-    if shutil.which(command_name):
-        try:
-            # Run the command and capture its output
-            result = subprocess.run(
-                version_command, shell=True, check=True, text=True, capture_output=True
-            )
-            version_info = (
-                result.stdout.strip() if result.stdout else result.stderr.strip()
-            )
-            version_info = (
-                version_info.strip()
-                .replace('"', "")
-                .replace("'", "")
-                .replace("(", "")
-                .replace(")", "")
-            )
-            version_info = version_info.strip() or "VERSIONUNKNOWN"
-        except subprocess.CalledProcessError:
-            # If the command doesn't exist, handle the exception
+    # Prepare table header
+    output_list = ["", "| Tool | Version |", "|---------|---------|"]
+
+    # Run each command and capture output
+    for command_name, version_command in commands.items():
+        if shutil.which(command_name):
+            try:
+                # Run the command and capture its output
+                result = subprocess.run(
+                    version_command,
+                    shell=True,
+                    check=True,
+                    text=True,
+                    capture_output=True,
+                )
+                version_info = (
+                    result.stdout.strip() if result.stdout else result.stderr.strip()
+                )
+                version_info = (
+                    version_info.strip()
+                    .replace('"', "")
+                    .replace("'", "")
+                    .replace("(", "")
+                    .replace(")", "")
+                )
+                version_info = version_info.strip() or "VERSIONUNKNOWN"
+            except subprocess.CalledProcessError:
+                # If the command doesn't exist, handle the exception
+                version_info = "NOTINDOCKER"
+        else:
             version_info = "NOTINDOCKER"
-    else:
-        version_info = "NOTINDOCKER"
-    # Print in Markdown table format
-    print(f"| {command_name} | {version_info} |")
+        # Print in Markdown table format
+        output_list.append(f"| {command_name} | {version_info} |")
+    output_list.append("")
+    return output_list
 
-print("")
+
+def main(args):
+    output_list = create_table(args)
+    output_str = "\n".join(output_list)
+
+    if args.output:
+        with open(args.output, "w") as outfile:
+            outfile.write(output_str)
+    else:
+        print(output_str, end="")
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    main(args)

--- a/src/ccbr_actions/data/__init__.py
+++ b/src/ccbr_actions/data/__init__.py
@@ -1,0 +1,34 @@
+"""
+Data files for CCBR actions
+"""
+
+import importlib.resources
+
+
+def get_file_path(filename):
+    """
+    Get the file path for a given filename within the package.
+
+    This function retrieves the path to a specified file within the package's
+    data files using the `importlib.resources` module.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file for which to retrieve the path.
+
+    Returns
+    -------
+    pathlib.Path
+        The path to the specified file within the package.
+
+    Examples
+    --------
+    >>> get_file_path('tool_version_commands.json')
+    PosixPath('/path/to/package/tool_version_commands.json')
+    """
+    pkg_files = importlib.resources.files(__package__)
+    file_path = pkg_files / filename
+    if not file_path.exists():
+        raise FileNotFoundError(f"{filename} not found in package data")
+    return file_path

--- a/src/ccbr_actions/data/tool_version_commands.json
+++ b/src/ccbr_actions/data/tool_version_commands.json
@@ -1,0 +1,18 @@
+{
+  "bcftools": "bcftools 2>&1 | grep -m1 -i version |awk -F\":\" '{print $2}'",
+  "bedops": "bedops --version 2>&1 | grep -i version |awk -F\":\" '{print $2}' ",
+  "bedtools": "bedtools --version 2>&1 | awk '{print $NF}'",
+  "bowtie": "bowtie --version 2>&1 | grep -i version | grep bowtie | awk '{print $NF}'",
+  "bowtie2": "bowtie2 --version 2>&1 | grep -i version | grep bowtie | awk '{print $NF}'",
+  "bwa": "bwa 2>&1 | grep Version | awk '{print $NF}'",
+  "cutadapt": "cutadapt --version 2>&1 | head -n1 | awk '{print $NF}'",
+  "git": "git --version 2>&1 | awk '{print $NF}'",
+  "java": "java -version 2>&1 | head -n1 | awk '{print $NF}'",
+  "multiqc": "multiqc --version 2>&1 | awk '{print $NF}'",
+  "parallel": "parallel --version | head -n1 | awk '{print $NF}'",
+  "pigz": "pigz --version 2>&1 | awk '{print $NF}'",
+  "python2": "python2 --version 2>&1 | awk '{print $NF}'",
+  "python3": "python3 --version 2>&1 | awk '{print $NF}'",
+  "samtools": "samtools --version 2>&1 | head -n1 | awk '{print $NF}'",
+  "vcftools": "vcftools --version 2>&1 |  head -n1 | awk '{print $NF}'"
+}

--- a/tests/data/tool_version_commands.json
+++ b/tests/data/tool_version_commands.json
@@ -1,0 +1,18 @@
+{
+  "bcftools": "bcftools 2>&1 | grep -m1 -i version |awk -F\":\" '{print $2}'",
+  "bedops": "bedops --version 2>&1 | grep -i version |awk -F\":\" '{print $2}' ",
+  "bedtools": "bedtools --version 2>&1 | awk '{print $NF}'",
+  "bowtie": "bowtie --version 2>&1 | grep -i version | grep bowtie | awk '{print $NF}'",
+  "bowtie2": "bowtie2 --version 2>&1 | grep -i version | grep bowtie | awk '{print $NF}'",
+  "bwa": "bwa 2>&1 | grep Version | awk '{print $NF}'",
+  "cutadapt": "cutadapt --version 2>&1 | head -n1 | awk '{print $NF}'",
+  "git": "git --version 2>&1 | awk '{print $NF}'",
+  "java": "java -version 2>&1 | head -n1 | awk '{print $NF}'",
+  "multiqc": "multiqc --version 2>&1 | awk '{print $NF}'",
+  "parallel": "parallel --version | head -n1 | awk '{print $NF}'",
+  "pigz": "pigz --version 2>&1 | awk '{print $NF}'",
+  "python2": "python2 --version 2>&1 | awk '{print $NF}'",
+  "python3": "python3 --version 2>&1 | awk '{print $NF}'",
+  "samtools": "samtools --version 2>&1 | head -n1 | awk '{print $NF}'",
+  "vcftools": "vcftools --version 2>&1 |  head -n1 | awk '{print $NF}'"
+}

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,15 @@
+from ccbr_actions.data import get_file_path
+import pytest
+
+
+def test_get_file_path():
+    file = get_file_path("tool_version_commands.json")
+    assert all([file.exists(), file.name == "tool_version_commands.json"])
+
+
+def test_get_file_path_error():
+    with pytest.raises(FileNotFoundError) as exc_info:
+        get_file_path("not_a_file.txt")
+        assert "FileNotFoundError: not_a_file.txt not found in package data" == str(
+            exc_info
+        )

--- a/tests/test_print_versions.py
+++ b/tests/test_print_versions.py
@@ -29,7 +29,7 @@ def test_print_versions_outfile():
         )
         with open(filename, "r") as md_file:
             out_file = md_file.read()
-        assert out_print == f"{out_file}\n"
+        assert out_print == f"{out_file}"
 
 
 print(shell_run("print_versions.py --json tests/data/tool_version_commands.json"))

--- a/tests/test_print_versions.py
+++ b/tests/test_print_versions.py
@@ -30,6 +30,3 @@ def test_print_versions_outfile():
         with open(filename, "r") as md_file:
             out_file = md_file.read()
         assert out_print.strip() == out_file.strip()
-
-
-print(shell_run("print_versions.py --json tests/data/tool_version_commands.json"))

--- a/tests/test_print_versions.py
+++ b/tests/test_print_versions.py
@@ -1,0 +1,9 @@
+import pytest
+
+from ccbr_tools.shell import shell_run
+
+
+def test_print_versions_errors():
+    with pytest.raises(Exception) as exc_info:
+        out = shell_run("print_versions.py")
+        assert "error: the following arguments are required: --json" in out

--- a/tests/test_print_versions.py
+++ b/tests/test_print_versions.py
@@ -1,4 +1,6 @@
+import pathlib
 import pytest
+import tempfile
 
 from ccbr_tools.shell import shell_run
 
@@ -7,3 +9,27 @@ def test_print_versions_errors():
     with pytest.raises(Exception) as exc_info:
         out = shell_run("print_versions.py")
         assert "error: the following arguments are required: --json" in out
+
+
+def test_print_versions_header():
+    out = shell_run("print_versions.py --json tests/data/tool_version_commands.json")
+    assert out.startswith("\n| Tool | Version |\n")
+
+
+def test_print_versions_outfile():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        filename = pathlib.Path(tmp_dir) / "table.md"
+        # print
+        out_print = shell_run(
+            "print_versions.py --json tests/data/tool_version_commands.json"
+        )
+        # write
+        shell_run(
+            f"print_versions.py --json tests/data/tool_version_commands.json --output {filename}"
+        )
+        with open(filename, "r") as md_file:
+            out_file = md_file.read()
+        assert out_print == f"{out_file}\n"
+
+
+print(shell_run("print_versions.py --json tests/data/tool_version_commands.json"))

--- a/tests/test_print_versions.py
+++ b/tests/test_print_versions.py
@@ -29,7 +29,7 @@ def test_print_versions_outfile():
         )
         with open(filename, "r") as md_file:
             out_file = md_file.read()
-        assert out_print == f"{out_file}"
+        assert out_print.strip() == out_file.strip()
 
 
 print(shell_run("print_versions.py --json tests/data/tool_version_commands.json"))


### PR DESCRIPTION
## Changes

rather than push to the head branch, open a PR and merge it. this circumvents branch protection as long as the token has sufficient admin permissions.

## Issues

see also https://github.com/CCBR/Dockers2/pull/65

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
