### PR TITLE
fix: do not overwrite readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## actions development version
 
+- fix bug in `build-docker`, where version information was overwriting the docker container information in the README file & dockerhub description. (#35, @kelly-sovacool)
+
 ## actions 0.2.0
 
 - new actions & example workflows:

--- a/scripts/print_versions.py
+++ b/scripts/print_versions.py
@@ -69,7 +69,7 @@ def main(args):
     output_str = "\n".join(output_list)
 
     if args.output:
-        with open(args.output, "w") as outfile:
+        with open(args.output, "a") as outfile:
             outfile.write(output_str)
     else:
         print(output_str, end="")

--- a/tests/data/example_readme.md
+++ b/tests/data/example_readme.md
@@ -1,0 +1,1 @@
+hello world

--- a/tests/test_print_versions.py
+++ b/tests/test_print_versions.py
@@ -1,5 +1,6 @@
 import pathlib
 import pytest
+import shutil
 import tempfile
 
 from ccbr_tools.shell import shell_run
@@ -30,3 +31,20 @@ def test_print_versions_outfile():
         with open(filename, "r") as md_file:
             out_file = md_file.read()
         assert out_print.strip() == out_file.strip()
+
+
+def test_print_versions_append():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        infilename = pathlib.Path("tests") / "data" / "example_readme.md"
+        with open(infilename, "r") as md_file:
+            in_text = md_file.read()
+
+        outfilename = pathlib.Path(tmp_dir) / "example_readme.md"
+        shutil.copyfile(infilename, outfilename)
+
+        shell_run(
+            f"print_versions.py --json tests/data/tool_version_commands.json --output {outfilename}"
+        )
+        with open(outfilename, "r") as md_file:
+            out_text = md_file.read()
+        assert all([out_text.startswith(in_text), len(out_text) > len(in_text)])


### PR DESCRIPTION
## Changes

print_versions.py was overwriting the docker readme file instead of appending to it

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
