### PR TITLE
fix: dockerfile buildarg is overridden from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - fix `post-release` to force-push the sliding branch with the latest tag. (#61, @kelly-sovacool)
 - fix broken links to example workflows in docs website. (#62, @kelly-sovacool)
+- fix `build-docker` to set `$DOCKERFILE_PATH` separately from `$DOCKERFILE` to prevent variable clasing while building containers. (#63, @kelly-sovacool)
 
 ## actions 0.2.4
 

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -104,7 +104,7 @@ runs:
       shell: bash
       id: check_and_create_readme
       run: |
-        echo "DOCKERFILE: $DOCKERFILE"
+        echo "DOCKERFILE_PATH: $DOCKERFILE_PATH"
         echo "DOCKERFILE_BASENAME: $DOCKERFILE_BASENAME"
         echo "IMAGENAME: $IMAGENAME"
         echo "BASEIMAGENAME: $BASEIMAGENAME"
@@ -118,13 +118,13 @@ runs:
         echo -ne "Built on: $BUILD_DATE \n\n" >> $MDFILE
         echo -ne "Build tag: $BUILD_TAG \n\n" >> $MDFILE
         echo -ne "Base image: $BASEIMAGENAME \n\n" >> $MDFILE
-        echo -ne "Dockerfile path in repo: $DOCKERFILE \n\n" >> $MDFILE
+        echo -ne "Dockerfile path in repo: $DOCKERFILE_PATH \n\n" >> $MDFILE
 
     - name: Build and push Docker image
       id: build_and_push
       uses: docker/build-push-action@v5
       with:
-        file: ${{ env.DOCKERFILE }}
+        file: ${{ env.DOCKERFILE_PATH }}
         context: ${{ env.CONTEXT }}
         push: ${{ inputs.push }}
         tags: ${{ env.IMAGENAME }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -180,10 +180,10 @@ runs:
       with:
         token: ${{ github.token }}
         add-paths: ${{ env.MDFILE }}
-        commit-message: "docs: 🤖 update readme for ${{ env.DOCKERFILE }}"
+        commit-message: "docs: 🤖 update readme for ${{ env.DOCKERFILE_PATH }}"
         author: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"
         committer: "${{ inputs.github-actor }} <${{ inputs.github-actor }}@users.noreply.github.com>"
-        branch: "auto-pr/${{ env.DOCKERFILE }}"
+        branch: "auto-pr/${{ env.DOCKERFILE_PATH }}"
         title: "docs: 🤖 update readme for ${{ env.IMAGENAME }}"
 
     - name: Approve PR

--- a/scripts/prepare_docker_build_variables.sh
+++ b/scripts/prepare_docker_build_variables.sh
@@ -60,7 +60,7 @@ mdfile="${dn_dockerfile}/${tag}.README.md"
 artifact_name=$(echo $mdfile | sed 's|/|_|g')
 
 # Output each variable to $GITHUB_ENV to pass it to the next steps
-echo "DOCKERFILE=$dockerfile" >> $GITHUB_ENV
+echo "DOCKERFILE_PATH=$dockerfile" >> $GITHUB_ENV
 echo "DOCKERFILE_BASENAME=$bn_dockerfile" >> $GITHUB_ENV
 echo "CONTEXT=$(dirname $dockerfile)" >> $GITHUB_ENV
 echo "IMAGENAME=$imagename" >> $GITHUB_ENV


### PR DESCRIPTION
## Changes

where the relative path to the dockerfile was getting overridden, and couldn't be copied while building the container

## Issues

related to https://github.com/CCBR/Dockers2/pull/250

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
