### PR TITLE
fix: bump actions versions for node.js 20 deprecation

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -27,9 +27,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Lint
@@ -49,7 +49,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ${{ github.repository }}
 
-  build-status: # https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
+  build-status:
+    # https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
     runs-on: ubuntu-latest
     needs: [build]
     if: always()

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -19,11 +19,13 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-          args: --base ${{ github.workspace}} --verbose --no-progress --exclude-path './**/*.md' './**/*.html' './**/*.rst'
+          args:
+            --base ${{ github.workspace}} --verbose --no-progress --exclude-path
+            './**/*.md' './**/*.html' './**/*.rst'
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/docs-quartodoc.yml
+++ b/.github/workflows/docs-quartodoc.yml
@@ -24,10 +24,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: "pip"
@@ -69,7 +69,7 @@ jobs:
           python -m quartodoc interlinks
           quarto render
       - name: save docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-html
           path: docs/_site

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,7 +15,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: CCBR/actions/post-release@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0 # required to include tags
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - name: Install dependencies

--- a/add-issue-label-list/README.md
+++ b/add-issue-label-list/README.md
@@ -33,7 +33,7 @@ jobs:
   add-list:
     runs-on: ubuntu-latest
     steps:
-      - uses: CCBR/actions/add-issue-label-list@v0.5
+      - uses: CCBR/actions/add-issue-label-list@latest
         with:
           github-token: ${{ github.token }}
           issue-num: ${{ inputs.issue-num }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -78,7 +78,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "${{ inputs.python-version }}"
 
@@ -89,7 +89,7 @@ runs:
     - name: Login to DockerHub
       id: login_dockerhub
       if: ${{ inputs.push == 'true' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-token }}
@@ -127,7 +127,7 @@ runs:
 
     - name: Build and push Docker image
       id: build_and_push
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         file: ${{ env.DOCKERFILE_PATH }}
         context: ${{ env.CONTEXT }}
@@ -170,7 +170,7 @@ runs:
     - name: Update Docker Hub Description
       id: update_dockerhub_description
       if: ${{ (inputs.push == 'true') && (steps.build_and_push.outcome == 'success') }}
-      uses: peter-evans/dockerhub-description@v4
+      uses: peter-evans/dockerhub-description@v5
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-token }}
@@ -179,7 +179,7 @@ runs:
 
     - name: Create Pull Request
       id: create-pr
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
       if: ${{ steps.update_dockerhub_description.outcome == 'success' }}
       with:
         token: ${{ github.token }}
@@ -202,7 +202,7 @@ runs:
         PR: ${{ steps.create-pr.outputs.pull-request-number }}
 
     - name: upload readme file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ failure() || steps.approve-pr.outcome != 'success'}}
       with:
         name: ${{ env.ARTIFACT_NAME }}

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -78,7 +78,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v5
       with:
         python-version: "${{ inputs.python-version }}"
 

--- a/draft-release/README.md
+++ b/draft-release/README.md
@@ -59,7 +59,7 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # required to include tags
       - uses: CCBR/actions/draft-release@v0.5

--- a/examples/add-issue-label-list.yml
+++ b/examples/add-issue-label-list.yml
@@ -21,7 +21,7 @@ jobs:
   add-list:
     runs-on: ubuntu-latest
     steps:
-      - uses: CCBR/actions/add-issue-label-list@v0.5
+      - uses: CCBR/actions/add-issue-label-list@latest
         with:
           github-token: ${{ github.token }}
           issue-num: ${{ inputs.issue-num }}

--- a/examples/build-docker-auto.yml
+++ b/examples/build-docker-auto.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: changed-files
         name: Check changed files
@@ -75,14 +75,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: "checkout PR ${{ github.head_ref }}"
         if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }} # branch name of PR
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: "checkout push ${{ github.ref_name }}"
         if: github.event_name == 'push'
         with:

--- a/examples/build-docker-auto.yml
+++ b/examples/build-docker-auto.yml
@@ -89,7 +89,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_name }} # branch name of push
 
-      - uses: CCBR/actions/build-docker@v0.5
+      - uses: CCBR/actions/build-docker@latest
         with:
           dockerfile: ${{ matrix.file }}
           dockerhub-namespace: nciccbr

--- a/examples/build-docker-manual.yml
+++ b/examples/build-docker-manual.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: CCBR/actions/build-docker@v0.5
         with:

--- a/examples/build-docker-manual.yml
+++ b/examples/build-docker-manual.yml
@@ -61,7 +61,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
 
-      - uses: CCBR/actions/build-docker@v0.5
+      - uses: CCBR/actions/build-docker@latest
         with:
           dockerfile: ${{ github.event.inputs.dockerfile }}
           dockerhub-namespace: ${{ github.event.inputs.dockerhub-namespace }}

--- a/examples/build-nextflow.yml
+++ b/examples/build-nextflow.yml
@@ -22,9 +22,9 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -47,7 +47,7 @@ jobs:
           tool_name run -c conf/ci_stub.config -stub
           popd
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always() # run even if previous steps fail
         with:
           name: nextflow-log

--- a/examples/build-python.yml
+++ b/examples/build-python.yml
@@ -27,9 +27,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Lint

--- a/examples/build-snakemake.yml
+++ b/examples/build-snakemake.yml
@@ -14,7 +14,7 @@ jobs:
   dryrun-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: docker://snakemake/snakemake:v7.32.4
       - name: Dry-run
         run: |
@@ -40,7 +40,7 @@ jobs:
         python-version: ["3.11"]
         snakemake-version: ["7.32.3"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: test

--- a/examples/check-links.yml
+++ b/examples/check-links.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       issues: write # required for peter-evans/create-issue-from-file
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Link Checker
         id: lychee
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@v6
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/examples/docs-mkdocs.yml
+++ b/examples/docs-mkdocs.yml
@@ -24,7 +24,7 @@ jobs:
   mkdocs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: CCBR/actions/mkdocs-mike@v0.5

--- a/examples/docs-mkdocs.yml
+++ b/examples/docs-mkdocs.yml
@@ -27,6 +27,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: CCBR/actions/mkdocs-mike@v0.5
+      - uses: CCBR/actions/mkdocs-mike@latest
         with:
           github-token: ${{ github.token }}

--- a/examples/docs-quarto.yml
+++ b/examples/docs-quarto.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/examples/draft-release.yml
+++ b/examples/draft-release.yml
@@ -21,7 +21,7 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # required to include tags
       - uses: CCBR/actions/draft-release@v0.5

--- a/examples/post-release.yml
+++ b/examples/post-release.yml
@@ -14,7 +14,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: CCBR/actions/post-release@v0.5

--- a/examples/update-cff-R.yml
+++ b/examples/update-cff-R.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
@@ -53,7 +53,7 @@ jobs:
           cff_write(keys = mykeys)
 
         shell: Rscript {0}
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --files CITATION.cff
         continue-on-error: true

--- a/post-release/README.md
+++ b/post-release/README.md
@@ -41,7 +41,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: CCBR/actions/post-release@v0.5

--- a/sync-copilot-instructions/action.yml
+++ b/sync-copilot-instructions/action.yml
@@ -52,7 +52,7 @@ runs:
         owner: ${{ inputs.owner }}
 
     - name: Checkout target repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         persist-credentials: true


### PR DESCRIPTION
## Changes

see details here https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

also bump other versions to latest release

```
- actions/checkout: v3/v4 -> v6
- actions/setup-python: v3/v4/v6 -> v5
- actions/upload-artifact: v4 -> v7
- peter-evans/create-issue-from-file: v5 -> v6
- pre-commit/action: v3.0.0 -> v3.0.1
```

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
