### PR TITLE
feat: comparison mode for changed-files action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+README.md lingust-generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## actions development version
 
 - New action: `changed-files` to detect files that changed matching a pattern. (#152, @kelly-sovacool)
-  - Can compare only the most recent commit or the entire PR changes by setting the `comparison-mode` option. (#156, @kelly-sovacool)
+  - Can compare the most recent commit only or the entire PR changes by setting the `comparison-mode` option. (#156, @kelly-sovacool)
 - Bump actions versions to the latest release in anticipation of the node.js 20 deprecation. (#149, @kelly-sovacool)
 - Improve `maintain-milestones`:
   - Only close the immediately prior year's milestones after May of the current year for performance reviews. (#145, @kelly-sovacool)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## actions development version
 
 - New action: `changed-files` to detect files that changed matching a pattern. (#152, @kelly-sovacool)
+  - Can compare only the most recent commit or the entire PR changes by setting the `comparison-mode` option. (#156, @kelly-sovacool)
 - Bump actions versions to the latest release in anticipation of the node.js 20 deprecation. (#149, @kelly-sovacool)
 - Improve `maintain-milestones`:
   - Only close the immediately prior year's milestones after May of the current year for performance reviews. (#145, @kelly-sovacool)

--- a/changed-files/README.md
+++ b/changed-files/README.md
@@ -118,10 +118,11 @@ steps:
 - `ccbr-actions-version`: The version of ccbr_actions to use. Default:
   `main`.
 - `comparison-mode`: Comparison mode for collecting changed files.
-- latest-commit: for pull_request, compare head^…head (latest commit
-  only)
-- event (default): compare full event range (PR base…head or push
-  before…after) . Default: `latest-commit`.
+  Default: `latest-commit`.
+  - `latest-commit`: for pull_request, compare head^...head (latest
+    commit only).
+  - `event`: compare full event range (PR base...head or push
+    before...after).
 
 ## Outputs
 

--- a/changed-files/README.md
+++ b/changed-files/README.md
@@ -19,7 +19,7 @@ range for push events.
 
 ### Basic example
 
-[changed-files.yml](./examples/changed-files.yml)
+[changed-files.yml](/examples/changed-files.yml)
 
 Get all changed files:
 

--- a/changed-files/README.md
+++ b/changed-files/README.md
@@ -8,22 +8,27 @@ filter them using `.gitignore`-style patterns.
 
 This action retrieves the list of files changed in a pull request or
 push event, and can filter the results by one or more patterns. It uses
-the GitHub CLI to fetch the list of changed files and the `pathspec`
-library for pattern matching.
+the GitHub API (via Python) to fetch changed files and `pathspec` for
+pattern matching.
+
+By default, `comparison-mode` is `latest-commit`, which compares only
+the latest commit for pull requests and uses the full `before...after`
+range for push events.
 
 ## Usage
 
 ### Basic example
 
-[changed-files.yml](/examples/changed-files.yml)
+[changed-files.yml](./examples/changed-files.yml)
 
 Get all changed files:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
   - uses: CCBR/actions/changed-files@main
     id: changed-files
+    with:
+      comparison-mode: latest-commit
 
   - run: |
       echo "Changed files:"
@@ -36,10 +41,10 @@ Filter changed files by `.gitignore`-style patterns:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
   - uses: CCBR/actions/changed-files@main
     id: changed-files
     with:
+      comparison-mode: event
       paths: |
         src/**
         tests/**
@@ -55,10 +60,10 @@ Exclude specific files using negation patterns:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
   - uses: CCBR/actions/changed-files@main
     id: changed-files
     with:
+      comparison-mode: latest-commit
       paths: |
         *.py
         !tests/**
@@ -74,13 +79,13 @@ Specify Python version and ccbr-actions version:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
   - uses: CCBR/actions/changed-files@main
     id: changed-files
     with:
       paths: "docs/**"
       python-version: "3.12"
       ccbr-actions-version: "v1.0.0"
+      comparison-mode: latest-commit
 
   - run: |
       echo "Documentation files changed:"
@@ -108,6 +113,26 @@ steps:
       echo "${{ steps.changed-files.outputs.matched_files }}"
 ```
 
+### Full event range mode
+
+Use `comparison-mode: event` when you need all files changed across the
+full event range.
+
+```yaml
+steps:
+  - uses: CCBR/actions/changed-files@main
+    id: changed-files
+    with:
+      comparison-mode: event
+      paths: |
+        src/**
+        tests/**
+
+  - run: |
+      echo "Files changed across full event range:"
+      echo "${{ steps.changed-files.outputs.matched_files }}"
+```
+
 ## Inputs
 
 - `paths`: Pattern list in the .gitignore syntax to match against
@@ -118,11 +143,10 @@ steps:
 - `ccbr-actions-version`: The version of ccbr_actions to use. Default:
   `main`.
 - `comparison-mode`: Comparison mode for collecting changed files.
+- latest-commit (default): for pull_request, compare head^…head (latest
+  commit only)
+- event: compare full event range (PR base…head or push before…after) .
   Default: `latest-commit`.
-  - `latest-commit`: for pull_request, compare head^...head (latest
-    commit only).
-  - `event`: compare full event range (PR base...head or push
-    before...after).
 
 ## Outputs
 

--- a/changed-files/README.md
+++ b/changed-files/README.md
@@ -15,7 +15,7 @@ library for pattern matching.
 
 ### Basic example
 
-[changed-files.yml](/examples/changed-files.yml)
+[changed-files.yml](./examples/changed-files.yml)
 
 Get all changed files:
 
@@ -87,6 +87,27 @@ steps:
       echo "${{ steps.changed-files.outputs.matched_files }}"
 ```
 
+### Latest commit only (fork-safe PRs)
+
+Compare only the latest commit in pull requests (`head^...head`) so
+updates to older commits in a PR do not keep re-matching files from
+earlier pushes. This mode is API-based and works for both same-repo and
+fork pull requests.
+
+```yaml
+steps:
+  - uses: CCBR/actions/changed-files@main
+    id: changed-files
+    with:
+      paths: |
+        **/Dockerfile.*
+      comparison-mode: latest-commit
+
+  - run: |
+      echo "Dockerfiles changed in latest commit:"
+      echo "${{ steps.changed-files.outputs.matched_files }}"
+```
+
 ## Inputs
 
 - `paths`: Pattern list in the .gitignore syntax to match against
@@ -96,6 +117,11 @@ steps:
 - `python-version`: The version of Python to install. Default: `3.11`.
 - `ccbr-actions-version`: The version of ccbr_actions to use. Default:
   `main`.
+- `comparison-mode`: Comparison mode for collecting changed files.
+- latest-commit: for pull_request, compare head^…head (latest commit
+  only)
+- event (default): compare full event range (PR base…head or push
+  before…after) . Default: `latest-commit`.
 
 ## Outputs
 

--- a/changed-files/README.md
+++ b/changed-files/README.md
@@ -15,7 +15,7 @@ library for pattern matching.
 
 ### Basic example
 
-[changed-files.yml](./examples/changed-files.yml)
+[changed-files.yml](/examples/changed-files.yml)
 
 Get all changed files:
 

--- a/changed-files/README.md
+++ b/changed-files/README.md
@@ -118,11 +118,10 @@ steps:
 - `ccbr-actions-version`: The version of ccbr_actions to use. Default:
   `main`.
 - `comparison-mode`: Comparison mode for collecting changed files.
+- latest-commit (default): for pull_request, compare head^…head (latest
+  commit only)
+- event: compare full event range (PR base…head or push before…after) .
   Default: `latest-commit`.
-  - `latest-commit`: for pull_request, compare head^...head (latest
-    commit only).
-  - `event`: compare full event range (PR base...head or push
-    before...after).
 
 ## Outputs
 

--- a/changed-files/README.qmd
+++ b/changed-files/README.qmd
@@ -94,6 +94,27 @@ steps:
       echo "${{ steps.changed-files.outputs.matched_files }}"
 ```
 
+### Latest commit only (fork-safe PRs)
+
+Compare only the latest commit in pull requests (`head^...head`) so
+updates to older commits in a PR do not keep re-matching files from
+earlier pushes. This mode is API-based and works for both same-repo and
+fork pull requests.
+
+```yaml
+steps:
+  - uses: CCBR/actions/changed-files@main
+    id: changed-files
+    with:
+      paths: |
+        **/Dockerfile.*
+      comparison-mode: latest-commit
+
+  - run: |
+      echo "Dockerfiles changed in latest commit:"
+      echo "${{ steps.changed-files.outputs.matched_files }}"
+```
+
 ```{python}
 print(ccbr_actions.docs.action_markdown_io(action))
 ```

--- a/changed-files/README.qmd
+++ b/changed-files/README.qmd
@@ -16,7 +16,9 @@ print(ccbr_actions.docs.action_markdown_desc(action))
 
 Get a list of changed files in a GitHub Actions workflow and optionally filter them using `.gitignore`-style patterns.
 
-This action retrieves the list of files changed in a pull request or push event, and can filter the results by one or more patterns. It uses the GitHub CLI to fetch the list of changed files and the `pathspec` library for pattern matching.
+This action retrieves the list of files changed in a pull request or push event, and can filter the results by one or more patterns. It uses the GitHub API (via Python) to fetch changed files and `pathspec` for pattern matching.
+
+By default, `comparison-mode` is `latest-commit`, which compares only the latest commit for pull requests and uses the full `before...after` range for push events.
 
 ## Usage
 
@@ -28,9 +30,10 @@ Get all changed files:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
   - uses: CCBR/actions/changed-files@main
     id: changed-files
+    with:
+      comparison-mode: latest-commit
 
   - run: |
       echo "Changed files:"
@@ -43,10 +46,10 @@ Filter changed files by `.gitignore`-style patterns:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
   - uses: CCBR/actions/changed-files@main
     id: changed-files
     with:
+      comparison-mode: event
       paths: |
         src/**
         tests/**
@@ -62,10 +65,10 @@ Exclude specific files using negation patterns:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
   - uses: CCBR/actions/changed-files@main
     id: changed-files
     with:
+      comparison-mode: latest-commit
       paths: |
         *.py
         !tests/**
@@ -81,13 +84,13 @@ Specify Python version and ccbr-actions version:
 
 ```yaml
 steps:
-  - uses: actions/checkout@v6
   - uses: CCBR/actions/changed-files@main
     id: changed-files
     with:
       paths: "docs/**"
       python-version: "3.12"
       ccbr-actions-version: "v1.0.0"
+      comparison-mode: latest-commit
 
   - run: |
       echo "Documentation files changed:"
@@ -112,6 +115,25 @@ steps:
 
   - run: |
       echo "Dockerfiles changed in latest commit:"
+      echo "${{ steps.changed-files.outputs.matched_files }}"
+```
+
+### Full event range mode
+
+Use `comparison-mode: event` when you need all files changed across the full event range.
+
+```yaml
+steps:
+  - uses: CCBR/actions/changed-files@main
+    id: changed-files
+    with:
+      comparison-mode: event
+      paths: |
+        src/**
+        tests/**
+
+  - run: |
+      echo "Files changed across full event range:"
       echo "${{ steps.changed-files.outputs.matched_files }}"
 ```
 

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -11,24 +11,27 @@ branding:
 
 inputs:
   paths:
-    type: string
     description: Pattern list in the .gitignore syntax to match against changed files
     required: false
   token:
-    type: string
     description: GitHub token used for `gh api` calls
     required: false
     default: "${{ github.token }}"
   python-version:
-    type: string
     description: The version of Python to install
     required: false
     default: "3.11"
   ccbr-actions-version:
-    type: string
     description: The version of ccbr_actions to use
     required: false
     default: "main"
+  comparison-mode:
+    description: |
+      Comparison mode for collecting changed files.
+      - latest-commit: for pull_request, compare head^...head (latest commit only)
+      - event (default): compare full event range (PR base...head or push before...after)
+    required: false
+    default: "latest-commit"
 
 outputs:
   changed_files:
@@ -61,13 +64,31 @@ runs:
       env:
         GH_TOKEN: "${{ inputs.token }}"
       run: |
+        # Validate comparison mode
+        comparison_mode="${{ inputs.comparison-mode }}"
+        if [ "$comparison_mode" != "event" ] && [ "$comparison_mode" != "latest-commit" ]; then
+          echo "::error::Invalid comparison mode: '$comparison_mode'. Must be 'event' or 'latest-commit'."
+          exit 1
+        fi
+
         EOS=$(openssl rand -hex 64)
         {
           echo "changed_file_list<<$EOS"
-          if [ "${{github.event_name}}" = "pull_request" ]; then
-            gh api 'repos/${{github.event.pull_request.base.repo.full_name}}/compare/${{github.event.pull_request.base.sha}}...${{github.event.pull_request.head.label}}' --jq '.files[].filename'
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ inputs.comparison-mode }}" = "latest-commit" ]; then
+            head_repo='${{ github.event.pull_request.head.repo.full_name }}'
+            head_sha='${{ github.event.pull_request.head.sha }}'
+            parent_sha=$(gh api "repos/${head_repo}/commits/${head_sha}" --jq '.parents[0].sha // empty')
+
+            # Fallback to full PR diff when the head commit has no parent.
+            if [ -n "$parent_sha" ]; then
+              gh api "repos/${head_repo}/compare/${parent_sha}...${head_sha}" --jq '.files[].filename'
+            else
+              gh api 'repos/${{ github.event.pull_request.base.repo.full_name}}/compare/${{ github.event.pull_request.base.sha}}...${{ github.event.pull_request.head.label}}' --jq '.files[].filename'
+            fi
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            gh api 'repos/${{ github.event.pull_request.base.repo.full_name}}/compare/${{ github.event.pull_request.base.sha}}...${{ github.event.pull_request.head.label}}' --jq '.files[].filename'
           else
-            gh api 'repos/${{github.repository}}/compare/${{github.event.before}}...${{github.event.after}}' --jq '.files[].filename'
+            gh api 'repos/${{ github.repository}}/compare/${{ github.event.before}}...${{ github.event.after}}' --jq '.files[].filename'
           fi
           echo "$EOS"
         } >> "$GITHUB_OUTPUT"
@@ -79,6 +100,10 @@ runs:
         CHANGED_FILE_LIST: ${{ steps.get-changed-files.outputs.changed_file_list }}
         PATHS: ${{ inputs.paths }}
       run: |
+        import os
         from ccbr_actions.changed_files import get_changed_files
-        get_changed_files()
+
+        changed_file_list = os.environ.get("CHANGED_FILE_LIST", "")
+        paths = os.environ.get("PATHS", "")
+        get_changed_files(changed_file_list=changed_file_list, paths=paths)
       shell: python

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -36,16 +36,16 @@ inputs:
 outputs:
   changed_files:
     description: A multi-line string containing the list of changed files.
-    value: ${{ fromJson(steps.match-paths.outputs.result).changed_files }}
+    value: ${{ fromJson(steps.get-changed-files.outputs.result).changed_files }}
   changed_files_json:
     description: A JSON string containing the list of changed files.
-    value: ${{ fromJson(steps.match-paths.outputs.result).changed_files_json }}
+    value: ${{ fromJson(steps.get-changed-files.outputs.result).changed_files_json }}
   matched_files:
     description: A multi-line string containing the list of changed files matching `paths` patterns.  Empty ("") if `paths` is not given.
-    value: ${{ fromJson(steps.match-paths.outputs.result).matched_files }}
+    value: ${{ fromJson(steps.get-changed-files.outputs.result).matched_files }}
   matched_files_json:
     description: A JSON string containing the list of changed files matching `paths` patterns.  Empty ("[]") if `paths` is not given.
-    value: ${{ fromJson(steps.match-paths.outputs.result).matched_files_json }}
+    value: ${{ fromJson(steps.get-changed-files.outputs.result).matched_files_json }}
 
 runs:
   using: composite
@@ -63,47 +63,33 @@ runs:
       name: Get Changed Files
       env:
         GH_TOKEN: "${{ inputs.token }}"
-      run: |
-        # Validate comparison mode
-        comparison_mode="${{ inputs.comparison-mode }}"
-        if [ "$comparison_mode" != "event" ] && [ "$comparison_mode" != "latest-commit" ]; then
-          echo "::error::Invalid comparison mode: '$comparison_mode'. Must be 'event' or 'latest-commit'."
-          exit 1
-        fi
-
-        EOS=$(openssl rand -hex 64)
-        {
-          echo "changed_file_list<<$EOS"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ "$comparison_mode" = "latest-commit" ]; then
-            head_repo='${{ github.event.pull_request.head.repo.full_name }}'
-            head_sha='${{ github.event.pull_request.head.sha }}'
-            parent_sha=$(gh api "repos/${head_repo}/commits/${head_sha}" --jq '.parents[0].sha // empty')
-
-            # Fallback to full PR diff when the head commit has no parent.
-            if [ -n "$parent_sha" ]; then
-              gh api "repos/${head_repo}/compare/${parent_sha}...${head_sha}" --jq '.files[].filename'
-            else
-              gh api 'repos/${{ github.event.pull_request.base.repo.full_name}}/compare/${{ github.event.pull_request.base.sha}}...${{ github.event.pull_request.head.label}}' --jq '.files[].filename'
-            fi
-          elif [ "${{ github.event_name }}" = "pull_request" ] && [ "$comparison_mode" = "event" ]; then
-            gh api 'repos/${{ github.event.pull_request.base.repo.full_name}}/compare/${{ github.event.pull_request.base.sha}}...${{ github.event.pull_request.head.label}}' --jq '.files[].filename'
-          else
-            gh api 'repos/${{ github.repository}}/compare/${{ github.event.before}}...${{ github.event.after}}' --jq '.files[].filename'
-          fi
-          echo "$EOS"
-        } >> "$GITHUB_OUTPUT"
-      shell: bash
-
-    - name: Match Paths
-      id: match-paths
-      env:
-        CHANGED_FILE_LIST: ${{ steps.get-changed-files.outputs.changed_file_list }}
         PATHS: ${{ inputs.paths }}
+        EVENT_NAME: ${{ github.event_name }}
+        COMPARISON_MODE: ${{ inputs.comparison-mode }}
+        REPOSITORY: ${{ github.repository }}
+        BEFORE: ${{ github.event.before }}
+        AFTER: ${{ github.event.after }}
+        PR_BASE_REPO_FULL_NAME: ${{ github.event.pull_request.base.repo.full_name }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_LABEL: ${{ github.event.pull_request.head.label }}
+        PR_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         import os
         from ccbr_actions.changed_files import get_changed_files
 
-        changed_file_list = os.environ.get("CHANGED_FILE_LIST", "")
-        paths = os.environ.get("PATHS", "")
-        get_changed_files(changed_file_list=changed_file_list, paths=paths)
+        get_changed_files(
+            paths=os.environ.get("PATHS", ""),
+            event_name=os.environ.get("EVENT_NAME", ""),
+            comparison_mode=os.environ.get("COMPARISON_MODE", "latest-commit"),
+            repository=os.environ.get("REPOSITORY", ""),
+            before=os.environ.get("BEFORE", ""),
+            after=os.environ.get("AFTER", ""),
+            pr_base_repo_full_name=os.environ.get("PR_BASE_REPO_FULL_NAME", ""),
+            pr_base_sha=os.environ.get("PR_BASE_SHA", ""),
+            pr_head_label=os.environ.get("PR_HEAD_LABEL", ""),
+            pr_head_repo_full_name=os.environ.get("PR_HEAD_REPO_FULL_NAME", ""),
+            pr_head_sha=os.environ.get("PR_HEAD_SHA", ""),
+            token=os.environ.get("GH_TOKEN", ""),
+        )
       shell: python

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -74,7 +74,7 @@ runs:
         EOS=$(openssl rand -hex 64)
         {
           echo "changed_file_list<<$EOS"
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ inputs.comparison-mode }}" = "latest-commit" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "$comparison_mode" = "latest-commit" ]; then
             head_repo='${{ github.event.pull_request.head.repo.full_name }}'
             head_sha='${{ github.event.pull_request.head.sha }}'
             parent_sha=$(gh api "repos/${head_repo}/commits/${head_sha}" --jq '.parents[0].sha // empty')

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -28,8 +28,8 @@ inputs:
   comparison-mode:
     description: |
       Comparison mode for collecting changed files.
-      - latest-commit: for pull_request, compare head^...head (latest commit only)
-      - event (default): compare full event range (PR base...head or push before...after)
+      - latest-commit (default): for pull_request, compare head^...head (latest commit only)
+      - event: compare full event range (PR base...head or push before...after)
     required: false
     default: "latest-commit"
 

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -85,7 +85,7 @@ runs:
             else
               gh api 'repos/${{ github.event.pull_request.base.repo.full_name}}/compare/${{ github.event.pull_request.base.sha}}...${{ github.event.pull_request.head.label}}' --jq '.files[].filename'
             fi
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          elif [ "${{ github.event_name }}" = "pull_request" ] && [ "$comparison_mode" = "event" ]; then
             gh api 'repos/${{ github.event.pull_request.base.repo.full_name}}/compare/${{ github.event.pull_request.base.sha}}...${{ github.event.pull_request.head.label}}' --jq '.files[].filename'
           else
             gh api 'repos/${{ github.repository}}/compare/${{ github.event.before}}...${{ github.event.after}}' --jq '.files[].filename'

--- a/examples/changed-files.yml
+++ b/examples/changed-files.yml
@@ -13,11 +13,10 @@ jobs:
   changed-files:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
       - uses: CCBR/actions/changed-files@main
         id: changed-files
         with:
+          # Default mode; shown explicitly for clarity.
           comparison-mode: latest-commit
 
       - name: Print all changed files
@@ -28,11 +27,10 @@ jobs:
   filter-by-pattern:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
       - uses: CCBR/actions/changed-files@main
         id: changed-files
         with:
+          # Full event range mode.
           comparison-mode: event
           paths: |
             src/**
@@ -46,11 +44,10 @@ jobs:
   docs-only:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
       - uses: CCBR/actions/changed-files@main
         id: changed-files
         with:
+          # Latest-commit mode is useful for incremental PR checks.
           comparison-mode: latest-commit
           paths: |
             docs/**

--- a/examples/changed-files.yml
+++ b/examples/changed-files.yml
@@ -17,6 +17,8 @@ jobs:
 
       - uses: CCBR/actions/changed-files@main
         id: changed-files
+        with:
+          comparison-mode: latest-commit
 
       - name: Print all changed files
         run: |
@@ -31,6 +33,7 @@ jobs:
       - uses: CCBR/actions/changed-files@main
         id: changed-files
         with:
+          comparison-mode: event
           paths: |
             src/**
             tests/**
@@ -48,6 +51,7 @@ jobs:
       - uses: CCBR/actions/changed-files@main
         id: changed-files
         with:
+          comparison-mode: latest-commit
           paths: |
             docs/**
             *.md

--- a/src/ccbr_actions/actions.py
+++ b/src/ccbr_actions/actions.py
@@ -8,6 +8,7 @@ import requests
 import uuid
 import warnings
 
+from .github import GITHUB_API_URL, github_api_headers, github_api_post
 from .util import path_resolve
 from .versions import get_latest_release_tag
 
@@ -108,20 +109,14 @@ def trigger_workflow(workflow_name, branch, repo, inputs=None, debug=False):
         branch (str): The branch to trigger the workflow on.
         repo (str): The GitHub repository to trigger the workflow in.
     """
-    url = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow_name}/dispatches"
-    headers = {
-        "Accept": "application/vnd.github.v3+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    if (
-        "GITHUB_TOKEN" in os.environ
-    ):  # required for curl usage, not needed for gh api usage
-        headers["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
+    url = f"{GITHUB_API_URL}/repos/{repo}/actions/workflows/{workflow_name}/dispatches"
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = github_api_headers(token=token)
     data = {"ref": branch}
     if inputs and isinstance(inputs, dict):
         data.update(inputs)
     if not debug:
-        response = requests.post(url, headers=headers, json=data)
+        response = github_api_post(url=url, token=token, json=data)
         if response.status_code != 204:
             warnings.warn(f"Failed to trigger workflow:\n{response.text}")
         return response

--- a/src/ccbr_actions/changed_files.py
+++ b/src/ccbr_actions/changed_files.py
@@ -3,14 +3,11 @@ Helpers for changed-files action matching logic.
 """
 
 import json
-import requests
 
 from pathspec import GitIgnoreSpec
 
 from .actions import set_output
-
-
-GITHUB_API_URL = "https://api.github.com"
+from .github import GITHUB_API_URL, github_api_get
 
 
 def validate_comparison_mode(comparison_mode):
@@ -32,30 +29,6 @@ def validate_comparison_mode(comparison_mode):
             f"Invalid comparison mode: {comparison_mode!r}. Must be one of: {sorted(allowed_modes)}"
         )
     return comparison_mode
-
-
-def github_api_get(url, token=None, session=requests):
-    """
-    Perform an authenticated GET request against the GitHub API.
-
-    Args:
-        url (str): API URL to fetch.
-        token (str, optional): GitHub token.
-        session: Object with a requests-compatible ``get`` method.
-
-    Returns:
-        dict: Parsed JSON response.
-    """
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-
-    response = session.get(url, headers=headers)
-    response.raise_for_status()
-    return response.json()
 
 
 def format_multiline_file_list(files):
@@ -84,7 +57,7 @@ def get_pull_request_changed_file_list(
     pr_head_repo_full_name,
     pr_head_sha,
     token=None,
-    session=requests,
+    session=None,
 ):
     """
     Get changed files for a pull request event.
@@ -146,7 +119,7 @@ def get_changed_file_list(
     pr_head_repo_full_name="",
     pr_head_sha="",
     token=None,
-    session=requests,
+    session=None,
 ):
     """
     Get the changed file list for the current GitHub Actions event.
@@ -239,7 +212,7 @@ def get_changed_files(
     pr_head_repo_full_name="",
     pr_head_sha="",
     token=None,
-    session=requests,
+    session=None,
 ):
     """
     Compute and emit the `result` output for the changed-files action.

--- a/src/ccbr_actions/changed_files.py
+++ b/src/ccbr_actions/changed_files.py
@@ -3,7 +3,6 @@ Helpers for changed-files action matching logic.
 """
 
 import json
-import os
 
 from pathspec import GitIgnoreSpec
 
@@ -50,25 +49,17 @@ def match_paths_json(changed_file_list, paths=None):
     return json.dumps(match_paths(changed_file_list=changed_file_list, paths=paths))
 
 
-def get_changed_files(changed_file_list=None, paths=None):
+def get_changed_files(changed_file_list, paths=""):
     """
     Compute and emit the `result` output for the changed-files action.
 
     Args:
-        changed_file_list (str, optional): Newline-separated changed file paths.
-            When omitted, this is read from CHANGED_FILE_LIST.
+        changed_file_list (str): Newline-separated changed file paths.
         paths (str, optional): .gitignore-style pattern list.
-            When omitted, this is read from PATHS.
 
     Returns:
         str: JSON-encoded payload written to the `result` output.
     """
-    changed_file_list = (
-        os.environ.get("CHANGED_FILE_LIST", "")
-        if changed_file_list is None
-        else changed_file_list
-    )
-    paths = os.environ.get("PATHS", "") if paths is None else paths
     result = match_paths_json(changed_file_list=changed_file_list, paths=paths)
     set_output("result", result)
     return result

--- a/src/ccbr_actions/changed_files.py
+++ b/src/ccbr_actions/changed_files.py
@@ -3,14 +3,191 @@ Helpers for changed-files action matching logic.
 """
 
 import json
+import requests
 
 from pathspec import GitIgnoreSpec
 
 from .actions import set_output
 
 
+GITHUB_API_URL = "https://api.github.com"
+
+
+def validate_comparison_mode(comparison_mode):
+    """
+    Validate the comparison mode used to collect changed files.
+
+    Args:
+        comparison_mode (str): Comparison mode name.
+
+    Returns:
+        str: The validated comparison mode.
+
+    Raises:
+        ValueError: If the comparison mode is not recognized.
+    """
+    allowed_modes = {"event", "latest-commit"}
+    if comparison_mode not in allowed_modes:
+        raise ValueError(
+            f"Invalid comparison mode: {comparison_mode!r}. Must be one of: {sorted(allowed_modes)}"
+        )
+    return comparison_mode
+
+
+def github_api_get(url, token=None, session=requests):
+    """
+    Perform an authenticated GET request against the GitHub API.
+
+    Args:
+        url (str): API URL to fetch.
+        token (str, optional): GitHub token.
+        session: Object with a requests-compatible ``get`` method.
+
+    Returns:
+        dict: Parsed JSON response.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    response = session.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
 def format_multiline_file_list(files):
     return "".join(f"{file}\n" for file in files)
+
+
+def format_changed_files_from_api(compare_payload):
+    """
+    Extract filenames from a GitHub compare API payload.
+
+    Args:
+        compare_payload (dict): Response JSON from the compare API.
+
+    Returns:
+        str: Newline-separated filenames.
+    """
+    files = [file_info["filename"] for file_info in compare_payload.get("files", [])]
+    return format_multiline_file_list(files)
+
+
+def get_pull_request_changed_file_list(
+    comparison_mode,
+    pr_base_repo_full_name,
+    pr_base_sha,
+    pr_head_label,
+    pr_head_repo_full_name,
+    pr_head_sha,
+    token=None,
+    session=requests,
+):
+    """
+    Get changed files for a pull request event.
+
+    Args:
+        comparison_mode (str): Comparison mode.
+        pr_base_repo_full_name (str): Base repository full name.
+        pr_base_sha (str): Base commit SHA.
+        pr_head_label (str): Pull request head label.
+        pr_head_repo_full_name (str): Head repository full name.
+        pr_head_sha (str): Head commit SHA.
+        token (str, optional): GitHub token.
+        session: Object with a requests-compatible ``get`` method.
+
+    Returns:
+        str: Newline-separated changed files.
+    """
+    comparison_mode = validate_comparison_mode(comparison_mode)
+
+    if comparison_mode == "latest-commit":
+        commit_payload = github_api_get(
+            url=f"{GITHUB_API_URL}/repos/{pr_head_repo_full_name}/commits/{pr_head_sha}",
+            token=token,
+            session=session,
+        )
+        parent_sha = next(
+            (
+                parent.get("sha")
+                for parent in commit_payload.get("parents", [])
+                if parent.get("sha")
+            ),
+            "",
+        )
+        if parent_sha:
+            compare_payload = github_api_get(
+                url=f"{GITHUB_API_URL}/repos/{pr_head_repo_full_name}/compare/{parent_sha}...{pr_head_sha}",
+                token=token,
+                session=session,
+            )
+            return format_changed_files_from_api(compare_payload)
+
+    compare_payload = github_api_get(
+        url=f"{GITHUB_API_URL}/repos/{pr_base_repo_full_name}/compare/{pr_base_sha}...{pr_head_label}",
+        token=token,
+        session=session,
+    )
+    return format_changed_files_from_api(compare_payload)
+
+
+def get_changed_file_list(
+    event_name,
+    comparison_mode="latest-commit",
+    repository="",
+    before="",
+    after="",
+    pr_base_repo_full_name="",
+    pr_base_sha="",
+    pr_head_label="",
+    pr_head_repo_full_name="",
+    pr_head_sha="",
+    token=None,
+    session=requests,
+):
+    """
+    Get the changed file list for the current GitHub Actions event.
+
+    Args:
+        event_name (str): GitHub event name.
+        comparison_mode (str): Comparison mode.
+        repository (str): Repository full name for non-PR events.
+        before (str): Previous SHA for push events.
+        after (str): New SHA for push events.
+        pr_base_repo_full_name (str): Base repository full name.
+        pr_base_sha (str): Base SHA for pull requests.
+        pr_head_label (str): Head label for pull requests.
+        pr_head_repo_full_name (str): Head repository full name.
+        pr_head_sha (str): Head SHA for pull requests.
+        token (str, optional): GitHub token.
+        session: Object with a requests-compatible ``get`` method.
+
+    Returns:
+        str: Newline-separated changed files.
+    """
+    comparison_mode = validate_comparison_mode(comparison_mode)
+
+    if event_name == "pull_request":
+        return get_pull_request_changed_file_list(
+            comparison_mode=comparison_mode,
+            pr_base_repo_full_name=pr_base_repo_full_name,
+            pr_base_sha=pr_base_sha,
+            pr_head_label=pr_head_label,
+            pr_head_repo_full_name=pr_head_repo_full_name,
+            pr_head_sha=pr_head_sha,
+            token=token,
+            session=session,
+        )
+
+    compare_payload = github_api_get(
+        url=f"{GITHUB_API_URL}/repos/{repository}/compare/{before}...{after}",
+        token=token,
+        session=session,
+    )
+    return format_changed_files_from_api(compare_payload)
 
 
 def match_paths(changed_file_list, paths=None):
@@ -49,17 +226,56 @@ def match_paths_json(changed_file_list, paths=None):
     return json.dumps(match_paths(changed_file_list=changed_file_list, paths=paths))
 
 
-def get_changed_files(changed_file_list, paths=""):
+def get_changed_files(
+    paths="",
+    event_name="",
+    comparison_mode="latest-commit",
+    repository="",
+    before="",
+    after="",
+    pr_base_repo_full_name="",
+    pr_base_sha="",
+    pr_head_label="",
+    pr_head_repo_full_name="",
+    pr_head_sha="",
+    token=None,
+    session=requests,
+):
     """
     Compute and emit the `result` output for the changed-files action.
 
     Args:
-        changed_file_list (str): Newline-separated changed file paths.
         paths (str, optional): .gitignore-style pattern list.
+        event_name (str): GitHub event name.
+        comparison_mode (str): Comparison mode.
+        repository (str): Repository full name for non-PR events.
+        before (str): Previous SHA for push events.
+        after (str): New SHA for push events.
+        pr_base_repo_full_name (str): Base repository full name.
+        pr_base_sha (str): Base SHA for pull requests.
+        pr_head_label (str): Head label for pull requests.
+        pr_head_repo_full_name (str): Head repository full name.
+        pr_head_sha (str): Head SHA for pull requests.
+        token (str, optional): GitHub token.
+        session: Object with a requests-compatible ``get`` method.
 
     Returns:
         str: JSON-encoded payload written to the `result` output.
     """
+    changed_file_list = get_changed_file_list(
+        event_name=event_name,
+        comparison_mode=comparison_mode,
+        repository=repository,
+        before=before,
+        after=after,
+        pr_base_repo_full_name=pr_base_repo_full_name,
+        pr_base_sha=pr_base_sha,
+        pr_head_label=pr_head_label,
+        pr_head_repo_full_name=pr_head_repo_full_name,
+        pr_head_sha=pr_head_sha,
+        token=token,
+        session=session,
+    )
     result = match_paths_json(changed_file_list=changed_file_list, paths=paths)
     set_output("result", result)
     return result

--- a/src/ccbr_actions/github.py
+++ b/src/ccbr_actions/github.py
@@ -1,0 +1,95 @@
+"""
+Shared utilities for interacting with the GitHub API.
+"""
+
+import requests
+
+
+GITHUB_API_URL = "https://api.github.com"
+
+
+def github_api_headers(token=None, accept="application/vnd.github+json"):
+    """
+    Build standard headers for GitHub API requests.
+
+    Args:
+        token (str, optional): GitHub token.
+        accept (str): Accept header value.
+
+    Returns:
+        dict: HTTP headers.
+    """
+    headers = {
+        "Accept": accept,
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def github_api_request(method, url, token=None, session=requests, **kwargs):
+    """
+    Execute a GitHub API request.
+
+    Args:
+        method (str): HTTP method.
+        url (str): Full API URL.
+        token (str, optional): GitHub token.
+        session: Object with a requests-compatible ``request`` method.
+        **kwargs: Additional arguments passed to ``session.request``.
+
+    Returns:
+        requests.Response: HTTP response.
+    """
+    if session is None:
+        session = requests
+
+    headers = github_api_headers(token=token)
+    provided_headers = kwargs.pop("headers", {}) or {}
+    headers.update(provided_headers)
+
+    if hasattr(session, "request"):
+        return session.request(method=method, url=url, headers=headers, **kwargs)
+
+    method_name = method.lower()
+    request_fn = getattr(session, method_name)
+    return request_fn(url, headers=headers, **kwargs)
+
+
+def github_api_get(url, token=None, session=requests, **kwargs):
+    """
+    Perform a GET request against the GitHub API and parse JSON.
+
+    Args:
+        url (str): Full API URL.
+        token (str, optional): GitHub token.
+        session: Object with a requests-compatible ``request`` method.
+        **kwargs: Additional arguments passed to ``github_api_request``.
+
+    Returns:
+        dict: Parsed JSON response.
+    """
+    response = github_api_request(
+        method="GET", url=url, token=token, session=session, **kwargs
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def github_api_post(url, token=None, session=requests, **kwargs):
+    """
+    Perform a POST request against the GitHub API.
+
+    Args:
+        url (str): Full API URL.
+        token (str, optional): GitHub token.
+        session: Object with a requests-compatible ``request`` method.
+        **kwargs: Additional arguments passed to ``github_api_request``.
+
+    Returns:
+        requests.Response: HTTP response.
+    """
+    return github_api_request(
+        method="POST", url=url, token=token, session=session, **kwargs
+    )

--- a/src/ccbr_actions/github.py
+++ b/src/ccbr_actions/github.py
@@ -4,7 +4,6 @@ Shared utilities for interacting with the GitHub API.
 
 import requests
 
-
 GITHUB_API_URL = "https://api.github.com"
 
 

--- a/tests/test_changed_files.py
+++ b/tests/test_changed_files.py
@@ -58,10 +58,8 @@ def test_match_paths_json_matches_python_payload():
 def test_get_changed_files_sets_result_output(monkeypatch, tmp_path):
     output_file = tmp_path / "github_output.txt"
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
-    monkeypatch.setenv("CHANGED_FILE_LIST", "a.txt\n")
-    monkeypatch.setenv("PATHS", "*.txt")
 
-    result_json = get_changed_files()
+    result_json = get_changed_files(changed_file_list="a.txt\n", paths="*.txt")
 
     payload = json.loads(result_json)
     assert payload["matched_files"] == "a.txt\n"

--- a/tests/test_changed_files.py
+++ b/tests/test_changed_files.py
@@ -1,7 +1,39 @@
 import json
 import pathlib
+import pytest
 
-from ccbr_actions.changed_files import get_changed_files, match_paths, match_paths_json
+from ccbr_actions.changed_files import (
+    format_changed_files_from_api,
+    get_changed_file_list,
+    get_changed_files,
+    get_pull_request_changed_file_list,
+    match_paths,
+    match_paths_json,
+    validate_comparison_mode,
+)
+
+
+class MockResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class MockSession:
+    def __init__(self, payloads):
+        self.payloads = payloads
+        self.calls = []
+
+    def get(self, url, headers=None):
+        self.calls.append((url, headers))
+        return MockResponse(self.payloads[url])
 
 
 def test_match_paths_without_patterns_mirrors_js_output_shape():
@@ -55,11 +87,138 @@ def test_match_paths_json_matches_python_payload():
     assert json.loads(result_json) == match_paths(changed_file_list, paths)
 
 
+def test_validate_comparison_mode_rejects_invalid_value():
+    with pytest.raises(ValueError, match="Invalid comparison mode"):
+        validate_comparison_mode("invalid")
+
+
+def test_format_changed_files_from_api_formats_newline_list():
+    compare_payload = {"files": [{"filename": "a.txt"}, {"filename": "b.txt"}]}
+
+    assert format_changed_files_from_api(compare_payload) == "a.txt\nb.txt\n"
+
+
+def test_get_pull_request_changed_file_list_uses_latest_commit_compare_when_parent_exists():
+    session = MockSession(
+        {
+            "https://api.github.com/repos/fork/repo/commits/headsha": {
+                "parents": [{"sha": "parentsha"}]
+            },
+            "https://api.github.com/repos/fork/repo/compare/parentsha...headsha": {
+                "files": [{"filename": "Dockerfile.cpu"}]
+            },
+        }
+    )
+
+    result = get_pull_request_changed_file_list(
+        comparison_mode="latest-commit",
+        pr_base_repo_full_name="base/repo",
+        pr_base_sha="basesha",
+        pr_head_label="fork:branch",
+        pr_head_repo_full_name="fork/repo",
+        pr_head_sha="headsha",
+        token="token",
+        session=session,
+    )
+
+    assert result == "Dockerfile.cpu\n"
+    assert [call[0] for call in session.calls] == [
+        "https://api.github.com/repos/fork/repo/commits/headsha",
+        "https://api.github.com/repos/fork/repo/compare/parentsha...headsha",
+    ]
+
+
+def test_get_pull_request_changed_file_list_falls_back_to_full_pr_compare_without_parent():
+    session = MockSession(
+        {
+            "https://api.github.com/repos/fork/repo/commits/headsha": {"parents": []},
+            "https://api.github.com/repos/base/repo/compare/basesha...fork:branch": {
+                "files": [{"filename": "Dockerfile.gpu"}]
+            },
+        }
+    )
+
+    result = get_pull_request_changed_file_list(
+        comparison_mode="latest-commit",
+        pr_base_repo_full_name="base/repo",
+        pr_base_sha="basesha",
+        pr_head_label="fork:branch",
+        pr_head_repo_full_name="fork/repo",
+        pr_head_sha="headsha",
+        session=session,
+    )
+
+    assert result == "Dockerfile.gpu\n"
+    assert session.calls[-1][0] == (
+        "https://api.github.com/repos/base/repo/compare/basesha...fork:branch"
+    )
+
+
+def test_get_changed_file_list_uses_event_compare_for_pull_request_mode_event():
+    session = MockSession(
+        {
+            "https://api.github.com/repos/base/repo/compare/basesha...fork:branch": {
+                "files": [{"filename": "src/app.py"}]
+            }
+        }
+    )
+
+    result = get_changed_file_list(
+        event_name="pull_request",
+        comparison_mode="event",
+        pr_base_repo_full_name="base/repo",
+        pr_base_sha="basesha",
+        pr_head_label="fork:branch",
+        pr_head_repo_full_name="fork/repo",
+        pr_head_sha="headsha",
+        session=session,
+    )
+
+    assert result == "src/app.py\n"
+
+
+def test_get_changed_file_list_uses_push_compare_for_push_events():
+    session = MockSession(
+        {
+            "https://api.github.com/repos/CCBR/actions/compare/before...after": {
+                "files": [{"filename": "README.md"}]
+            }
+        }
+    )
+
+    result = get_changed_file_list(
+        event_name="push",
+        comparison_mode="latest-commit",
+        repository="CCBR/actions",
+        before="before",
+        after="after",
+        session=session,
+    )
+
+    assert result == "README.md\n"
+
+
 def test_get_changed_files_sets_result_output(monkeypatch, tmp_path):
     output_file = tmp_path / "github_output.txt"
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
 
-    result_json = get_changed_files(changed_file_list="a.txt\n", paths="*.txt")
+    session = MockSession(
+        {
+            "https://api.github.com/repos/CCBR/actions/compare/before...after": {
+                "files": [{"filename": "a.txt"}]
+            }
+        }
+    )
+
+    result_json = get_changed_files(
+        paths="*.txt",
+        event_name="push",
+        comparison_mode="latest-commit",
+        repository="CCBR/actions",
+        before="before",
+        after="after",
+        session=session,
+    )
 
     payload = json.loads(result_json)
     assert payload["matched_files"] == "a.txt\n"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,87 @@
+from ccbr_actions.github import (
+    github_api_get,
+    github_api_headers,
+    github_api_post,
+    github_api_request,
+)
+
+
+class MockResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+class MockRequestSession:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, headers=None, **kwargs):
+        self.calls.append((method, url, headers, kwargs))
+        return MockResponse({"ok": True})
+
+
+class MockMethodSession:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, headers=None, **kwargs):
+        self.calls.append(("GET", url, headers, kwargs))
+        return MockResponse({"files": []})
+
+    def post(self, url, headers=None, **kwargs):
+        self.calls.append(("POST", url, headers, kwargs))
+        return MockResponse({"created": True}, status_code=201)
+
+
+def test_github_api_headers_includes_auth_when_token_set():
+    headers = github_api_headers(token="abc")
+
+    assert headers["Authorization"] == "Bearer abc"
+    assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+
+
+def test_github_api_request_supports_request_interface():
+    session = MockRequestSession()
+
+    response = github_api_request(
+        method="GET",
+        url="https://api.github.com/repos/CCBR/actions",
+        token="abc",
+        session=session,
+    )
+
+    assert response.status_code == 200
+    assert session.calls[0][0] == "GET"
+
+
+def test_github_api_get_supports_method_only_interface():
+    session = MockMethodSession()
+
+    payload = github_api_get(
+        url="https://api.github.com/repos/CCBR/actions/compare/a...b",
+        session=session,
+    )
+
+    assert payload == {"files": []}
+    assert session.calls[0][0] == "GET"
+
+
+def test_github_api_post_supports_method_only_interface():
+    session = MockMethodSession()
+
+    response = github_api_post(
+        url="https://api.github.com/repos/CCBR/actions/actions/workflows/test.yml/dispatches",
+        session=session,
+        json={"ref": "main"},
+    )
+
+    assert response.status_code == 201
+    assert session.calls[0][0] == "POST"


### PR DESCRIPTION
## Changes

ensure the comparison can work for comparing only the most recent commit, or the entire PR.
also, do not use env vars in the python function.

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
