### PR TITLE
fix(changed-files): harden outputs with JSON-safe error fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## actions development version
 
+- Improve error message for `changed-files` when output is not set. (#162, @kelly-sovacool)
+
 ## actions 0.6.1
 
 - Fix `changed-files`: do not use pip cache with `setup-python` since the repo is not checked out. (#158, @kelly-sovacool)

--- a/changed-files/README.md
+++ b/changed-files/README.md
@@ -159,3 +159,5 @@ steps:
 - `matched_files_json`: A JSON string containing the list of changed
   files matching `paths` patterns. Empty (“\[\]”) if `paths` is not
   given..
+- `error`: Error message if changed file collection fails. Empty on
+  success..

--- a/changed-files/action.yml
+++ b/changed-files/action.yml
@@ -36,20 +36,31 @@ inputs:
 outputs:
   changed_files:
     description: A multi-line string containing the list of changed files.
-    value: ${{ fromJson(steps.get-changed-files.outputs.result).changed_files }}
+    value: ${{ fromJson(steps.get-changed-files.outputs.result || steps.init-result.outputs.result).changed_files }}
   changed_files_json:
     description: A JSON string containing the list of changed files.
-    value: ${{ fromJson(steps.get-changed-files.outputs.result).changed_files_json }}
+    value: ${{ fromJson(steps.get-changed-files.outputs.result || steps.init-result.outputs.result).changed_files_json }}
   matched_files:
     description: A multi-line string containing the list of changed files matching `paths` patterns.  Empty ("") if `paths` is not given.
-    value: ${{ fromJson(steps.get-changed-files.outputs.result).matched_files }}
+    value: ${{ fromJson(steps.get-changed-files.outputs.result || steps.init-result.outputs.result).matched_files }}
   matched_files_json:
     description: A JSON string containing the list of changed files matching `paths` patterns.  Empty ("[]") if `paths` is not given.
-    value: ${{ fromJson(steps.get-changed-files.outputs.result).matched_files_json }}
+    value: ${{ fromJson(steps.get-changed-files.outputs.result || steps.init-result.outputs.result).matched_files_json }}
+  error:
+    description: Error message if changed file collection fails. Empty on success.
+    value: ${{ fromJson(steps.get-changed-files.outputs.result || steps.init-result.outputs.result).error }}
 
 runs:
   using: composite
   steps:
+    - id: init-result
+      name: Initialize default result output
+      shell: bash
+      run: |
+        cat <<'EOF' >> "$GITHUB_OUTPUT"
+        result={"changed_files":"","changed_files_json":"[]","matched_files":"","matched_files_json":"[]","error":""}
+        EOF
+
     - uses: actions/setup-python@v6
       with:
         python-version: "${{ inputs.python-version }}"
@@ -74,10 +85,14 @@ runs:
         PR_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
         PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
+        import json
         import os
+        import traceback
+        from ccbr_actions.actions import set_output
         from ccbr_actions.changed_files import get_changed_files
 
-        get_changed_files(
+        try:
+          get_changed_files(
             paths=os.environ.get("PATHS", ""),
             event_name=os.environ.get("EVENT_NAME", ""),
             comparison_mode=os.environ.get("COMPARISON_MODE", "latest-commit"),
@@ -90,5 +105,26 @@ runs:
             pr_head_repo_full_name=os.environ.get("PR_HEAD_REPO_FULL_NAME", ""),
             pr_head_sha=os.environ.get("PR_HEAD_SHA", ""),
             token=os.environ.get("GH_TOKEN", ""),
-        )
+          )
+        except Exception as exc:
+          event_name = os.environ.get("EVENT_NAME", "")
+          comparison_mode = os.environ.get("COMPARISON_MODE", "")
+          repository = os.environ.get("REPOSITORY", "")
+          error_message = (
+            "changed-files action failed while collecting changed files. "
+            f"event_name={event_name}, comparison_mode={comparison_mode}, repository={repository}. "
+            "Check token permissions and that base/head refs are accessible. "
+            f"Original error: {exc}"
+          )
+          fallback = {
+            "changed_files": "",
+            "changed_files_json": "[]",
+            "matched_files": "",
+            "matched_files_json": "[]",
+            "error": error_message,
+          }
+          set_output("result", json.dumps(fallback))
+          print(f"::error::{error_message}")
+          print(traceback.format_exc())
+          raise
       shell: python


### PR DESCRIPTION
## Changes

Rather than failing with an error message about an invalid template, which makes it sound like the action syntax itself is invalid, set a default output JSON so the true error can be surfaced.

```
Error: The template is not valid. CCBR/actions/latest/changed-files/action.yml (Line: 39, Col: 12): Error reading JToken from JsonReader. Path '', line 0, position 0.,CCBR/actions/latest/changed-files/action.yml (Line: 42, Col: 12): Error reading JToken from JsonReader. Path '', line 0, position 0.,CCBR/actions/latest/changed-files/action.yml (Line: 45, Col: 12): Error reading JToken from JsonReader. Path '', line 0, position 0.,CCBR/actions/latest/changed-files/action.yml (Line: 48, Col: 12): Error reading JToken from JsonReader. Path '', line 0, position 0.
```

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
