### PR TITLE
feat: make build-docker aware of dockerhub build timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## actions development version
 
 - Fix `changed-files` JSON output handling and improve error messages. (#162, #163, @kelly-sovacool)
-- Fix `build-docker` behavior when run on forks: do not attempt to push to dockerhub if necessary secrets are not set. (#164, @kelly-sovacool)
-- New output from `build-docker`: `push_success` reports whether the docker image was pushed successfully. (#167, @kelly-sovacool)
+- `build-docker` updates:
+  - Fix when run on forks: do not attempt to push to dockerhub if necessary secrets are not set. (#164, @kelly-sovacool)
+  - New output: `push_success` reports whether the docker image was pushed successfully. (#167, @kelly-sovacool)
+  - Only build if the image on dockerhub does not exist or is older than the dockerfile timestamp. (#166, @kelly-sovacool)
 - Minor documentation improvements. (#165, @kelly-sovacool)
 
 ## actions 0.6.1

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -67,6 +67,8 @@ files change, see
   **Required.** Default: `feat`.
 - `push`: Push to DockerHub (leave unchecked to just build the container
   without pushing). **Required.**
+- `force_build`: Force docker image build even when the Docker Hub tag
+  is up-to-date. **Required.**
 - `ccbr-actions-version`: The version of ccbr_actions to use.
   **Required.** Default: `main`.
 - `python-version`: The version of Python to install. **Required.**

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -13,9 +13,9 @@ This action:
 - Prepares build-time variables by running a custom script.
 - Checks variables and creates a README file with build details in the
   same directory as the dockerfile.
-- Builds the Docker image in all cases; pushes only when effective push
-  mode is enabled.
-- Lists Docker images on the runner.
+- Checks whether the DockerHub tag is stale before building.
+- Builds the Docker image only when a build is needed; pushes only when
+  effective push mode is enabled.
 - Updates the DockerHub description with the contents of the README file
   only if the image was successfully pushed.
 - Opens and merges a PR with the README updates only when the DockerHub

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -60,26 +60,25 @@ files change, see
   **Required.** Default: `nciccbr`.
 - `dockerhub-username`: dockerhub username of a user with admin
   permissions for `dockerhub-namespace`. Recommend using secrets,
-  e.g. secrets.DOCKERHUB_USERNAME. **Required.**
+  e.g. secrets.DOCKERHUB_USERNAME.
 - `dockerhub-token`: dockerhub token with read & write permissions.
   Strongly recommend using secrets, e.g. secrets.DOCKERHUB_TOKEN.
 - `suffix`: Suffix to add to image tag eg. “dev” to add “-dev”.
   **Required.** Default: `feat`.
-- `push`: Push to DockerHub (leave unchecked to just build the container
-  without pushing). **Required.**
+- `push`: Push to DockerHub (if false, just build the container without
+  pushing). **Required.** Default: `false`.
 - `force_build`: Force docker image build even when the Docker Hub tag
-  is up-to-date. **Required.**
+  is up-to-date. **Required.** Default: `false`.
 - `ccbr-actions-version`: The version of ccbr_actions to use.
   **Required.** Default: `main`.
 - `python-version`: The version of Python to install. **Required.**
   Default: `3.11`.
 - `github-actor`: Username of GitHub actor for the git commit when the
-  README is updated. **Required.** Default:
-  `41898282+github-actions[bot]`.
+  README is updated. **Required.** Default: `258092125+CCBR-bot[bot]`.
 - `github-token`: GitHub Actions token (e.g. github.token).
   **Required.**
 - `print-versions`: Whether to print tool versions in the container for
-  the README file using `config-file`. Default: `True`.
+  the README file using `config-file`. Default: `true`.
 - `config-file`: Relative path to config file for tool version commands
   (text format with :: delimiters). If not provided and print-versions
   is true, the default config file from ccbr_actions will be used.

--- a/build-docker/README.qmd
+++ b/build-docker/README.qmd
@@ -23,8 +23,8 @@ This action:
   - Logs in to DockerHub only when effective push mode is enabled.
   - Prepares build-time variables by running a custom script.
   - Checks variables and creates a README file with build details in the same directory as the dockerfile.
-  - Builds the Docker image in all cases; pushes only when effective push mode is enabled.
-  - Lists Docker images on the runner.
+  - Checks whether the DockerHub tag is stale before building.
+  - Builds the Docker image only when a build is needed; pushes only when effective push mode is enabled.
   - Updates the DockerHub description with the contents of the README file only if the image was successfully pushed.
   - Opens and merges a PR with the README updates only when the DockerHub description update step runs successfully.
 

--- a/build-docker/action.yml
+++ b/build-docker/action.yml
@@ -35,6 +35,12 @@ inputs:
       Push to DockerHub (leave unchecked to just build the container without pushing).
     required: true
     default: false
+  force_build:
+    type: boolean
+    description: |
+      Force docker image build even when the Docker Hub tag is up-to-date.
+    required: true
+    default: false
   ccbr-actions-version:
     type: string
     description: |
@@ -143,8 +149,29 @@ runs:
         echo -ne "Base image: $BASEIMAGENAME \n\n" >> $MDFILE
         echo -ne "Dockerfile path in repo: $DOCKERFILE_PATH \n\n" >> $MDFILE
 
+    - name: Check whether image tag is stale
+      id: check_tag_staleness
+      shell: python
+      run: |
+        from ccbr_actions.actions import set_output
+        from ccbr_actions.docker import evaluate_docker_build_staleness_and_set_outputs
+
+        force_build = "${{ inputs.force_build }}".lower() == "true"
+        if force_build:
+          set_output("should_build", "true")
+          set_output("reason", "force_build_requested")
+          print("::notice::Force build requested. Skipping Docker Hub staleness check.")
+        else:
+          evaluate_docker_build_staleness_and_set_outputs(
+            dockerfile_path="${{ env.DOCKERFILE_PATH }}",
+            image_name="${{ env.IMAGENAME }}",
+            dockerhub_namespace="${{ inputs.dockerhub-namespace }}",
+            repo_name="${{ env.REPONAME }}",
+          )
+
     - name: Build and push Docker image
       id: build_and_push
+      if: ${{ steps.check_tag_staleness.outputs.should_build == 'true' }}
       uses: docker/build-push-action@v7
       with:
         file: ${{ env.DOCKERFILE_PATH }}
@@ -162,7 +189,7 @@ runs:
     - name: Run print_versions.sh inside Docker container
       shell: bash
       id: run_script_in_container
-      if: ${{ inputs.print-versions == 'true' }}
+      if: ${{ (inputs.print-versions == 'true') && (steps.check_tag_staleness.outputs.should_build == 'true') }}
       run: |
         script_src=$(command -v print_versions.sh)
         EXTRA_MOUNTS=""
@@ -182,7 +209,7 @@ runs:
 
     - name: Update Docker Hub Description
       id: update_dockerhub_description
-      if: ${{ (steps.resolve_push.outputs.push_enabled == 'true') && (steps.build_and_push.outcome == 'success') }}
+      if: ${{ (steps.check_tag_staleness.outputs.should_build == 'true') && (steps.resolve_push.outputs.push_enabled == 'true') && (steps.build_and_push.outcome == 'success') }}
       uses: peter-evans/dockerhub-description@v5
       with:
         username: ${{ inputs.dockerhub-username }}
@@ -216,7 +243,7 @@ runs:
 
     - name: upload readme file
       uses: actions/upload-artifact@v7
-      if: ${{ failure() || steps.approve-pr.outcome != 'success'}}
+      if: ${{ (steps.check_tag_staleness.outputs.should_build == 'true') && (failure() || steps.approve-pr.outcome != 'success') }}
       with:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.MDFILE }}

--- a/src/ccbr_actions/docker.py
+++ b/src/ccbr_actions/docker.py
@@ -127,14 +127,18 @@ def image_tag_from_image_name(image_name: str) -> str:
     Extract the tag suffix from a Docker image name.
 
     Args:
-        image_name (str): Docker image name in ``repo/image:tag`` format.
+        image_name (str): Docker image reference, optionally including a tag.
 
     Returns:
         str: Tag string, or an empty string if no tag is present.
     """
-    if ":" not in image_name:
-        return ""
-    return image_name.rsplit(":", 1)[1]
+    reference = image_name.split("@", 1)[0]
+    last_slash = reference.rfind("/")
+    last_colon = reference.rfind(":")
+    tag = ""
+    if last_colon > last_slash:
+        tag = reference[last_colon + 1 :]
+    return tag
 
 
 def dockerfile_last_commit_iso(dockerfile_path: str) -> str:

--- a/src/ccbr_actions/docker.py
+++ b/src/ccbr_actions/docker.py
@@ -7,7 +7,12 @@ from __future__ import annotations
 import datetime
 import os
 import pathlib
+import subprocess
 from typing import Dict, Optional
+
+import requests
+
+from .actions import set_output
 
 
 def base_image_name(dockerfile: str) -> str:
@@ -100,3 +105,187 @@ def prepare_docker_build_variables(
                 env_handle.write(f"{key}={value}\n")
 
     return values
+
+
+def parse_iso_timestamp(raw: str) -> datetime.datetime:
+    """
+    Parse an ISO timestamp and normalize it to UTC.
+
+    Args:
+        raw (str): ISO8601 timestamp (for example ``2026-01-01T12:00:00Z``).
+
+    Returns:
+        datetime.datetime: Timezone-aware UTC datetime.
+    """
+    return datetime.datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(
+        datetime.timezone.utc
+    )
+
+
+def image_tag_from_image_name(image_name: str) -> str:
+    """
+    Extract the tag suffix from a Docker image name.
+
+    Args:
+        image_name (str): Docker image name in ``repo/image:tag`` format.
+
+    Returns:
+        str: Tag string, or an empty string if no tag is present.
+    """
+    if ":" not in image_name:
+        return ""
+    return image_name.rsplit(":", 1)[1]
+
+
+def dockerfile_last_commit_iso(dockerfile_path: str) -> str:
+    """
+    Get the last git commit timestamp for the Dockerfile.
+
+    Args:
+        dockerfile_path (str): Path to the Dockerfile in the repository.
+
+    Returns:
+        str: ISO8601 timestamp from git ``%cI`` format.
+    """
+    return subprocess.check_output(
+        ["git", "log", "-1", "--format=%cI", "--", dockerfile_path],
+        text=True,
+    ).strip()
+
+
+def dockerhub_tag_last_updated(
+    dockerhub_namespace: str,
+    repo_name: str,
+    image_tag: str,
+    timeout: int = 20,
+    session=requests,
+) -> Optional[str]:
+    """
+    Get Docker Hub tag ``last_updated`` timestamp.
+
+    Args:
+        dockerhub_namespace (str): Docker Hub namespace/org.
+        repo_name (str): Docker Hub repository name.
+        image_tag (str): Docker image tag.
+        timeout (int): HTTP timeout in seconds.
+        session: Object with a requests-compatible ``get`` method.
+
+    Returns:
+        str or None: ISO8601 ``last_updated`` value, or ``None`` when tag is absent.
+    """
+    tag_url = (
+        f"https://hub.docker.com/v2/namespaces/{dockerhub_namespace}/"
+        f"repositories/{repo_name}/tags/{image_tag}"
+    )
+    response = session.get(tag_url, timeout=timeout)
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    payload = response.json()
+    return (payload.get("last_updated") or "").strip()
+
+
+def evaluate_docker_build_staleness(
+    dockerfile_path: str,
+    image_name: str,
+    dockerhub_namespace: str,
+    repo_name: str,
+) -> Dict[str, str]:
+    """
+    Decide whether to build a Docker image based on Dockerfile git history and tag freshness.
+
+    Args:
+        dockerfile_path (str): Path to Dockerfile in repository.
+        image_name (str): Target image name, including tag.
+        dockerhub_namespace (str): Docker Hub namespace/org.
+        repo_name (str): Docker Hub repository name.
+
+    Returns:
+        dict: Build decision fields suitable for GitHub Action outputs.
+    """
+    should_build = True
+    tag_exists = False
+    tag_last_updated = ""
+    reason = "default_build"
+
+    dockerfile_last_commit = dockerfile_last_commit_iso(dockerfile_path)
+    if not dockerfile_last_commit:
+        reason = "no_git_history_for_dockerfile"
+    else:
+        image_tag = image_tag_from_image_name(image_name)
+        if not image_tag:
+            reason = "missing_image_tag"
+        else:
+            try:
+                tag_last_updated_value = dockerhub_tag_last_updated(
+                    dockerhub_namespace=dockerhub_namespace,
+                    repo_name=repo_name,
+                    image_tag=image_tag,
+                )
+                if tag_last_updated_value is None:
+                    reason = "tag_not_found"
+                else:
+                    tag_exists = True
+                    tag_last_updated = tag_last_updated_value
+                    if tag_last_updated:
+                        dockerfile_dt = parse_iso_timestamp(dockerfile_last_commit)
+                        tag_dt = parse_iso_timestamp(tag_last_updated)
+                        should_build = dockerfile_dt > tag_dt
+                        if should_build:
+                            reason = "dockerfile_changed_after_tag"
+                        else:
+                            reason = "tag_is_newer_or_equal_to_dockerfile"
+                    else:
+                        reason = "tag_missing_last_updated"
+            except requests.HTTPError as exc:
+                status_code = getattr(exc.response, "status_code", "unknown")
+                reason = f"dockerhub_http_{status_code}"
+            except Exception as exc:
+                reason = f"dockerhub_lookup_failed_{type(exc).__name__}"
+
+    return {
+        "should_build": "true" if should_build else "false",
+        "tag_exists": "true" if tag_exists else "false",
+        "dockerfile_last_commit": dockerfile_last_commit,
+        "tag_last_updated": tag_last_updated,
+        "reason": reason,
+    }
+
+
+def evaluate_docker_build_staleness_and_set_outputs(
+    dockerfile_path: str,
+    image_name: str,
+    dockerhub_namespace: str,
+    repo_name: str,
+) -> Dict[str, str]:
+    """
+    Evaluate Docker build staleness and set step outputs.
+
+    Args:
+        dockerfile_path (str): Path to Dockerfile in repository.
+        image_name (str): Target image name, including tag.
+        dockerhub_namespace (str): Docker Hub namespace/org.
+        repo_name (str): Docker Hub repository name.
+
+    Returns:
+        dict: Build decision fields written to GitHub Action outputs.
+    """
+    result = evaluate_docker_build_staleness(
+        dockerfile_path=dockerfile_path,
+        image_name=image_name,
+        dockerhub_namespace=dockerhub_namespace,
+        repo_name=repo_name,
+    )
+    for name, value in result.items():
+        set_output(name, value)
+
+    if result["should_build"] == "true":
+        print(f"::notice::Will build image. reason={result['reason']}")
+    else:
+        print(
+            "::notice::Skipping docker build because Docker Hub tag is up-to-date "
+            f"(dockerfile_last_commit={result['dockerfile_last_commit']}, "
+            f"tag_last_updated={result['tag_last_updated']})."
+        )
+
+    return result

--- a/src/ccbr_actions/docker.py
+++ b/src/ccbr_actions/docker.py
@@ -145,12 +145,18 @@ def dockerfile_last_commit_iso(dockerfile_path: str) -> str:
         dockerfile_path (str): Path to the Dockerfile in the repository.
 
     Returns:
-        str: ISO8601 timestamp from git ``%cI`` format.
+        str: ISO8601 timestamp from git ``%cI`` format, or an empty string
+        when the file is missing, untracked, or has no git history.
     """
-    return subprocess.check_output(
-        ["git", "log", "-1", "--format=%cI", "--", dockerfile_path],
-        text=True,
-    ).strip()
+    last_commit_iso = ""
+    try:
+        last_commit_iso = subprocess.check_output(
+            ["git", "log", "-1", "--format=%cI", "--", dockerfile_path],
+            text=True,
+        ).strip()
+    except subprocess.CalledProcessError:
+        last_commit_iso = ""
+    return last_commit_iso
 
 
 def dockerhub_tag_last_updated(

--- a/tests/test_docker_build_freshness.py
+++ b/tests/test_docker_build_freshness.py
@@ -1,0 +1,102 @@
+import requests
+
+from ccbr_actions import docker as docker_module
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            http_error = requests.HTTPError(f"HTTP {self.status_code}")
+            http_error.response = self
+            raise http_error
+
+    def json(self):
+        return self._payload
+
+
+def test_image_tag_from_image_name():
+    assert docker_module.image_tag_from_image_name("nciccbr/tool:v1") == "v1"
+    assert docker_module.image_tag_from_image_name("nciccbr/tool") == ""
+
+
+def test_evaluate_docker_build_staleness_skip_when_tag_is_newer(monkeypatch):
+    def fake_check_output(*args, **kwargs):
+        return "2026-01-01T00:00:00+00:00\n"
+
+    def fake_get(*args, **kwargs):
+        return FakeResponse(
+            status_code=200,
+            payload={"last_updated": "2026-01-02T00:00:00.000000Z"},
+        )
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.evaluate_docker_build_staleness(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    assert result["should_build"] == "false"
+    assert result["tag_exists"] == "true"
+    assert result["reason"] == "tag_is_newer_or_equal_to_dockerfile"
+    assert result["tag_last_updated"] == "2026-01-02T00:00:00.000000Z"
+
+
+def test_evaluate_docker_build_staleness_build_when_tag_missing(monkeypatch):
+    def fake_check_output(*args, **kwargs):
+        return "2026-01-01T00:00:00+00:00\n"
+
+    def fake_get(*args, **kwargs):
+        return FakeResponse(status_code=404)
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.evaluate_docker_build_staleness(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    assert result["should_build"] == "true"
+    assert result["tag_exists"] == "false"
+    assert result["reason"] == "tag_not_found"
+    assert result["tag_last_updated"] == ""
+
+
+def test_evaluate_docker_build_staleness_and_set_outputs(
+    monkeypatch, github_output_file
+):
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output_file))
+
+    def fake_evaluate(*args, **kwargs):
+        return {
+            "should_build": "false",
+            "tag_exists": "true",
+            "dockerfile_last_commit": "2026-01-01T00:00:00+00:00",
+            "tag_last_updated": "2026-01-02T00:00:00.000000Z",
+            "reason": "tag_is_newer_or_equal_to_dockerfile",
+        }
+
+    monkeypatch.setattr(docker_module, "evaluate_docker_build_staleness", fake_evaluate)
+
+    result = docker_module.evaluate_docker_build_staleness_and_set_outputs(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    output_text = github_output_file.read_text()
+    assert result["should_build"] == "false"
+    assert "should_build<<" in output_text
+    assert "tag_exists<<" in output_text
+    assert "tag_is_newer_or_equal_to_dockerfile" in output_text

--- a/tests/test_docker_build_freshness.py
+++ b/tests/test_docker_build_freshness.py
@@ -1,5 +1,6 @@
 import requests
 
+
 from ccbr_actions import docker as docker_module
 
 
@@ -7,6 +8,7 @@ class FakeResponse:
     def __init__(self, status_code=200, payload=None):
         self.status_code = status_code
         self._payload = payload or {}
+        self.response = self
 
     def raise_for_status(self):
         if self.status_code >= 400:
@@ -18,9 +20,127 @@ class FakeResponse:
         return self._payload
 
 
+def test_parse_iso_timestamp():
+    """Test ISO timestamp parsing with various formats."""
+    dt1 = docker_module.parse_iso_timestamp("2026-01-01T12:00:00Z")
+    assert dt1.year == 2026
+    assert dt1.month == 1
+    assert dt1.day == 1
+    assert dt1.hour == 12
+
+    dt2 = docker_module.parse_iso_timestamp("2026-01-01T12:00:00+00:00")
+    assert dt2 == dt1
+
+    dt3 = docker_module.parse_iso_timestamp("2026-01-02T00:00:00.000000Z")
+    assert dt3.day == 2
+
+
+def test_parse_iso_timestamp_timezone_normalization():
+    """Test that timestamps are normalized to UTC."""
+    dt = docker_module.parse_iso_timestamp("2026-01-01T12:00:00Z")
+    assert dt.tzinfo is not None
+    assert str(dt.tzinfo) == "UTC"
+
+
+def test_dockerfile_last_commit_iso(monkeypatch):
+    """Test getting last commit timestamp from git."""
+    expected_commit = "2026-01-15T10:30:45+00:00\n"
+
+    def fake_check_output(*args, **kwargs):
+        return expected_commit
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+
+    result = docker_module.dockerfile_last_commit_iso("some/Dockerfile.v1")
+    assert result == "2026-01-15T10:30:45+00:00"
+
+
+def test_dockerfile_last_commit_iso_empty(monkeypatch):
+    """Test handling when dockerfile has no git history."""
+
+    def fake_check_output(*args, **kwargs):
+        return ""
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+
+    result = docker_module.dockerfile_last_commit_iso("untracked/Dockerfile.v1")
+    assert result == ""
+
+
+def test_dockerhub_tag_last_updated_success(monkeypatch):
+    """Test successful Docker Hub API call."""
+
+    def fake_get(*args, **kwargs):
+        return FakeResponse(
+            status_code=200,
+            payload={"last_updated": "2026-01-20T14:00:00.000000Z"},
+        )
+
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.dockerhub_tag_last_updated(
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+        image_tag="v1",
+    )
+    assert result == "2026-01-20T14:00:00.000000Z"
+
+
+def test_dockerhub_tag_last_updated_404(monkeypatch):
+    """Test Docker Hub API returning 404 for missing tag."""
+
+    def fake_get(*args, **kwargs):
+        return FakeResponse(status_code=404)
+
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.dockerhub_tag_last_updated(
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+        image_tag="nonexistent",
+    )
+    assert result is None
+
+
+def test_dockerhub_tag_last_updated_empty_payload(monkeypatch):
+    """Test Docker Hub API with missing last_updated field."""
+
+    def fake_get(*args, **kwargs):
+        return FakeResponse(status_code=200, payload={})
+
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.dockerhub_tag_last_updated(
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+        image_tag="v1",
+    )
+    assert result == ""
+
+
+def test_dockerhub_tag_last_updated_none_value(monkeypatch):
+    """Test Docker Hub API with None value for last_updated."""
+
+    def fake_get(*args, **kwargs):
+        return FakeResponse(status_code=200, payload={"last_updated": None})
+
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.dockerhub_tag_last_updated(
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+        image_tag="v1",
+    )
+    assert result == ""
+
+
 def test_image_tag_from_image_name():
     assert docker_module.image_tag_from_image_name("nciccbr/tool:v1") == "v1"
     assert docker_module.image_tag_from_image_name("nciccbr/tool") == ""
+    assert (
+        docker_module.image_tag_from_image_name("localhost:5000/myrepo/mytool:latest")
+        == "latest"
+    )
 
 
 def test_evaluate_docker_build_staleness_skip_when_tag_is_newer(monkeypatch):
@@ -72,6 +192,143 @@ def test_evaluate_docker_build_staleness_build_when_tag_missing(monkeypatch):
     assert result["tag_last_updated"] == ""
 
 
+def test_evaluate_docker_build_staleness_build_when_dockerfile_newer(monkeypatch):
+    """Test that build proceeds when Dockerfile is newer than tag."""
+
+    def fake_check_output(*args, **kwargs):
+        return "2026-01-03T00:00:00+00:00\n"
+
+    def fake_get(*args, **kwargs):
+        return FakeResponse(
+            status_code=200,
+            payload={"last_updated": "2026-01-02T00:00:00.000000Z"},
+        )
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.evaluate_docker_build_staleness(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    assert result["should_build"] == "true"
+    assert result["tag_exists"] == "true"
+    assert result["reason"] == "dockerfile_changed_after_tag"
+    assert result["dockerfile_last_commit"] == "2026-01-03T00:00:00+00:00"
+
+
+def test_evaluate_docker_build_staleness_no_git_history(monkeypatch):
+    """Test when Dockerfile has no git history."""
+
+    def fake_check_output(*args, **kwargs):
+        return ""
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+
+    result = docker_module.evaluate_docker_build_staleness(
+        dockerfile_path="untracked/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    assert result["should_build"] == "true"
+    assert result["reason"] == "no_git_history_for_dockerfile"
+    assert result["dockerfile_last_commit"] == ""
+
+
+def test_evaluate_docker_build_staleness_no_image_tag(monkeypatch):
+    """Test when image name has no tag."""
+
+    def fake_check_output(*args, **kwargs):
+        return "2026-01-01T00:00:00+00:00\n"
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+
+    result = docker_module.evaluate_docker_build_staleness(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    assert result["should_build"] == "true"
+    assert result["reason"] == "missing_image_tag"
+
+
+def test_evaluate_docker_build_staleness_missing_last_updated(monkeypatch):
+    """Test when Docker Hub tag exists but has no last_updated."""
+
+    def fake_check_output(*args, **kwargs):
+        return "2026-01-01T00:00:00+00:00\n"
+
+    def fake_get(*args, **kwargs):
+        return FakeResponse(status_code=200, payload={})
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.evaluate_docker_build_staleness(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    assert result["should_build"] == "true"
+    assert result["reason"] == "tag_missing_last_updated"
+
+
+def test_evaluate_docker_build_staleness_http_error(monkeypatch):
+    """Test handling of Docker Hub HTTP errors."""
+
+    def fake_check_output(*args, **kwargs):
+        return "2026-01-01T00:00:00+00:00\n"
+
+    def fake_get(*args, **kwargs):
+        response = FakeResponse(status_code=500)
+        return response
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.evaluate_docker_build_staleness(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    assert result["should_build"] == "true"
+    assert "dockerhub_http_500" in result["reason"]
+
+
+def test_evaluate_docker_build_staleness_generic_exception(monkeypatch):
+    """Test handling of generic exceptions during Docker Hub lookup."""
+
+    def fake_check_output(*args, **kwargs):
+        return "2026-01-01T00:00:00+00:00\n"
+
+    def fake_get(*args, **kwargs):
+        raise ValueError("Network error")
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+    monkeypatch.setattr(docker_module.requests, "get", fake_get)
+
+    result = docker_module.evaluate_docker_build_staleness(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    assert result["should_build"] == "true"
+    assert "dockerhub_lookup_failed_ValueError" in result["reason"]
+
+
 def test_evaluate_docker_build_staleness_and_set_outputs(
     monkeypatch, github_output_file
 ):
@@ -100,3 +357,34 @@ def test_evaluate_docker_build_staleness_and_set_outputs(
     assert "should_build<<" in output_text
     assert "tag_exists<<" in output_text
     assert "tag_is_newer_or_equal_to_dockerfile" in output_text
+
+
+def test_evaluate_docker_build_staleness_and_set_outputs_build_true(
+    monkeypatch, github_output_file
+):
+    """Test wrapper with should_build=true (build needed)."""
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output_file))
+
+    def fake_evaluate(*args, **kwargs):
+        return {
+            "should_build": "true",
+            "tag_exists": "false",
+            "dockerfile_last_commit": "2026-01-03T00:00:00+00:00",
+            "tag_last_updated": "",
+            "reason": "tag_not_found",
+        }
+
+    monkeypatch.setattr(docker_module, "evaluate_docker_build_staleness", fake_evaluate)
+
+    result = docker_module.evaluate_docker_build_staleness_and_set_outputs(
+        dockerfile_path="dockers2/example/Dockerfile.v1",
+        image_name="nciccbr/example:v1",
+        dockerhub_namespace="nciccbr",
+        repo_name="example",
+    )
+
+    output_text = github_output_file.read_text()
+    assert result["should_build"] == "true"
+    assert "should_build<<" in output_text
+    assert "reason<<" in output_text
+    assert "tag_not_found" in output_text

--- a/tests/test_docker_build_freshness.py
+++ b/tests/test_docker_build_freshness.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import requests
 
 
@@ -64,6 +66,18 @@ def test_dockerfile_last_commit_iso_empty(monkeypatch):
     monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
 
     result = docker_module.dockerfile_last_commit_iso("untracked/Dockerfile.v1")
+    assert result == ""
+
+
+def test_dockerfile_last_commit_iso_called_process_error(monkeypatch):
+    """Test that CalledProcessError is handled and returns an empty string."""
+
+    def fake_check_output(*args, **kwargs):
+        raise subprocess.CalledProcessError(128, "git")
+
+    monkeypatch.setattr(docker_module.subprocess, "check_output", fake_check_output)
+
+    result = docker_module.dockerfile_last_commit_iso("missing/Dockerfile.v1")
     assert result == ""
 
 
@@ -141,6 +155,8 @@ def test_image_tag_from_image_name():
         docker_module.image_tag_from_image_name("localhost:5000/myrepo/mytool:latest")
         == "latest"
     )
+    # registry with port but no explicit tag should return empty string
+    assert docker_module.image_tag_from_image_name("localhost:5000/myrepo/image") == ""
 
 
 def test_evaluate_docker_build_staleness_skip_when_tag_is_newer(monkeypatch):


### PR DESCRIPTION
## Changes

Check whether the built image exists on dockerhub and when the last push occurred.
Only re-build it if the Dockerfile has been updated more recently than the image on dockerhub.

## Issues

related to #151 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
