### PR TITLE
ci: re-trigger build workflow after auto-format commit

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-env:
-  GH_TOKEN: ${{ github.token }}
-
 permissions:
   contents: write
 
@@ -23,14 +20,24 @@ jobs:
         python-version: ["3.11"]
 
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CCBR_BOT_APP_ID }}
+          private-key: ${{ secrets.CCBR_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
           ref: ${{ github.head_ref }}
       - uses: actions/checkout@v6
         if: github.event_name != 'pull_request'
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -66,7 +73,7 @@ jobs:
 
       - name: commit & push
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "CCBR-bot"
+          git config --global user.email "258092125+ccbr-bot@users.noreply.github.com"
           git add .
           git commit -m "ci: 🤖 render readme & format everything with pre-commit" && git push || echo "nothing to commit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Bump actions versions.
 - Minor documentation improvements.
+- Use the CCBR-bot as the committer in `auto-format` so changes will trigger other workflows. (#171, @kelly-sovacool)
 
 ## actions 0.6.2
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ them for your needs.
 - [add-issue-label-list](examples/add-issue-label-list.yml)
 - [auto-format](examples/auto-format.yml)
 - [build-docker-auto](examples/build-docker-auto.yml)
+- [build-docker-dispatch](examples/build-docker-dispatch.yml)
 - [build-docker-manual](examples/build-docker-manual.yml)
 - [build-nextflow](examples/build-nextflow.yml)
 - [build-python](examples/build-python.yml)
@@ -39,6 +40,7 @@ them for your needs.
 - [post-release](examples/post-release.yml)
 - [sync-copilot-instructions](examples/sync-copilot-instructions.yml)
 - [techdev-project](examples/techdev-project.yml)
+- [trigger-docker-dispatch](examples/trigger-docker-dispatch.yml)
 - [update-cff-R](examples/update-cff-R.yml)
 - [user-projects](examples/user-projects.yml)
 

--- a/examples/auto-format.yml
+++ b/examples/auto-format.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-env:
-  GH_TOKEN: ${{ github.token }}
-
 permissions:
   contents: write
   pull-requests: write
@@ -20,20 +17,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CCBR_BOT_APP_ID }}
+          private-key: ${{ secrets.CCBR_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@v6
         if: github.event_name == 'pull_request'
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
           ref: ${{ github.head_ref }}
       - uses: actions/checkout@v6
         if: github.event_name != 'pull_request'
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: git config
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "CCBR-bot"
+          git config --global user.email "258092125+ccbr-bot@users.noreply.github.com"
 
       - id: changed-files
         name: Check changed files

--- a/examples/trigger-docker-dispatch.yml
+++ b/examples/trigger-docker-dispatch.yml
@@ -12,6 +12,10 @@ on:
   release:
     types: [published]
 
+env:
+  dockerfile_path: "Dockerfile"
+  docker_image_name: "scot"
+
 jobs:
   trigger-docker-build:
     runs-on: ubuntu-latest
@@ -34,8 +38,8 @@ jobs:
 
           owner_repo="${{ github.repository }}"
           ref=${{ github.ref_name }}
-          dockerfile_path="Dockerfile"
-          docker_image_name="mosuite"
+          dockerfile_path="${{ env.dockerfile_path }}"
+          docker_image_name="${{ env.docker_image_name }}"
 
           payload=$(jq -cn \
             --arg owner_repo "$owner_repo" \


### PR DESCRIPTION
## Changes

- Use the CCBR bot as the committer so commits from the auto-format workflow will trigger re-runs of other workflows

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write unit tests for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
