### PR TITLE
fix: preserve custom fields in CITATION.cff

### DIFF
--- a/.github/instructions/R.instructions.md
+++ b/.github/instructions/R.instructions.md
@@ -1,0 +1,21 @@
+---
+name: "R Standards"
+description: "Coding conventions for R files"
+applyTo: "**/*.R"
+---
+
+# R coding standards
+
+- R scripts must include function and class docstrings via roxygen2.
+- CLIs must be defined using the `argparse` package.
+- CLIs must support `--help` and document required/optional arguments.
+- R code should pass `lintr` and `air`.
+- Tests should be written with `testthat`.
+- Packages should pass `devtools::check()`.
+- R code should adhere to the tidyverse style guide. https://style.tidyverse.org/
+- Object names (functions, variables) should follow the snake_case style.
+- Function names should start with a verb.
+- Use the native pipe operator `|>`
+- If an external package is required, prefer packages from the tidyverse, r-lib, or other posit-affiliated organizations.
+- Prefer using tidyverse functions rather than base R functions where possible.
+- Only include one return statement at the end of a function, if a return statement is used at all. Explicit returns are preferred but not required for R functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## actions development version
 
+- Fix `draft-release` to preserve custom keys in `CITATION.cff` in R packages. (#180, @kelly-sovacool)
+
 ## actions 0.7.0
 
 - Add R package-aware release handling to `draft-release` and `post-release`. (#170, @kelly-sovacool, @copilot)

--- a/src/ccbr_actions/data/regenerate_citation_from_description.R
+++ b/src/ccbr_actions/data/regenerate_citation_from_description.R
@@ -7,14 +7,11 @@
 ## If the existing citation file already has an `identifiers` field, preserve it
 ## after cffr rewrites the rest of the citation metadata from DESCRIPTION.
 
-for (pkg in c("cffr", "yaml")) {
-  if (!requireNamespace(pkg, quietly = TRUE)) {
-    stop(
-      "Missing required R package: ",
-      pkg,
-      ". Install it in workflow setup (e.g. setup-r-dependencies)."
-    )
-  }
+if (!requireNamespace("cffr", quietly = TRUE)) {
+  stop(
+    "Missing required R package: cffr. ",
+    "Install it in workflow setup (e.g. setup-r-dependencies)."
+  )
 }
 
 citation_file <- Sys.getenv("CITATION_FILE")
@@ -28,7 +25,7 @@ if (file.exists(citation_file)) {
       }
     },
     error = function(e) {
-      message(
+      warning(
         "Unable to preserve existing CITATION.cff identifiers: ",
         conditionMessage(e)
       )
@@ -38,9 +35,12 @@ if (file.exists(citation_file)) {
 }
 
 setwd(dirname(Sys.getenv("DESCRIPTION_FILE")))
-cffr::cff_write(outfile = citation_file)
-if (!is.null(existing_identifiers)) {
-  yml <- yaml::read_yaml(citation_file)
-  yml$identifiers <- existing_identifiers
-  yaml::write_yaml(yml, citation_file)
+
+# Create citation with custom identifiers if they exist
+custom_keys <- if (is.null(existing_identifiers)) {
+  list()
+} else {
+  list(identifiers = existing_identifiers)
 }
+cf <- cffr::cff_create(keys = custom_keys)
+cffr::cff_write(cf, outfile = citation_file)

--- a/src/ccbr_actions/data/regenerate_citation_from_description.R
+++ b/src/ccbr_actions/data/regenerate_citation_from_description.R
@@ -1,0 +1,33 @@
+for (pkg in c("cffr", "yaml")) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    stop(
+      "Missing required R package: ",
+      pkg,
+      ". Install it in workflow setup (e.g. setup-r-dependencies)."
+    )
+  }
+}
+
+citation_file <- Sys.getenv("CITATION_FILE")
+custom_identifiers <- NULL
+if (file.exists(citation_file)) {
+  tryCatch(
+    {
+      existing_cff <- cffr::cff_read(citation_file)
+      if (!is.null(existing_cff[["identifiers"]])) {
+        custom_identifiers <- existing_cff[["identifiers"]]
+      }
+    },
+    error = function(e) {
+      NULL
+    }
+  )
+}
+
+setwd(dirname(Sys.getenv("DESCRIPTION_FILE")))
+cffr::cff_write(outfile = citation_file)
+if (!is.null(custom_identifiers)) {
+  yml <- yaml::read_yaml(citation_file)
+  yml$identifiers <- custom_identifiers
+  yaml::write_yaml(yml, citation_file)
+}

--- a/src/ccbr_actions/data/regenerate_citation_from_description.R
+++ b/src/ccbr_actions/data/regenerate_citation_from_description.R
@@ -1,3 +1,12 @@
+## Regenerate CITATION.cff from an R package DESCRIPTION file.
+##
+## Required environment variables:
+## - DESCRIPTION_FILE: path to the package DESCRIPTION file
+## - CITATION_FILE: path to the CITATION.cff file to overwrite
+##
+## If the existing citation file already has an `identifiers` field, preserve it
+## after cffr rewrites the rest of the citation metadata from DESCRIPTION.
+
 for (pkg in c("cffr", "yaml")) {
   if (!requireNamespace(pkg, quietly = TRUE)) {
     stop(
@@ -9,16 +18,20 @@ for (pkg in c("cffr", "yaml")) {
 }
 
 citation_file <- Sys.getenv("CITATION_FILE")
-custom_identifiers <- NULL
+existing_identifiers <- NULL
 if (file.exists(citation_file)) {
   tryCatch(
     {
       existing_cff <- cffr::cff_read(citation_file)
       if (!is.null(existing_cff[["identifiers"]])) {
-        custom_identifiers <- existing_cff[["identifiers"]]
+        existing_identifiers <- existing_cff[["identifiers"]]
       }
     },
     error = function(e) {
+      message(
+        "Unable to preserve existing CITATION.cff identifiers: ",
+        conditionMessage(e)
+      )
       NULL
     }
   )
@@ -26,8 +39,8 @@ if (file.exists(citation_file)) {
 
 setwd(dirname(Sys.getenv("DESCRIPTION_FILE")))
 cffr::cff_write(outfile = citation_file)
-if (!is.null(custom_identifiers)) {
+if (!is.null(existing_identifiers)) {
   yml <- yaml::read_yaml(citation_file)
-  yml$identifiers <- custom_identifiers
+  yml$identifiers <- existing_identifiers
   yaml::write_yaml(yml, citation_file)
 }

--- a/src/ccbr_actions/release.py
+++ b/src/ccbr_actions/release.py
@@ -96,16 +96,35 @@ def regenerate_citation_from_description(
     """
     Regenerate CITATION.cff from DESCRIPTION using cffr.
 
+    Preserves custom fields (e.g., identifiers) from the existing CITATION.cff file.
+
     Args:
         citation_filepath (str): Path to output CITATION.cff.
         description_filepath (str): Path to DESCRIPTION file.
         debug (bool): If True, print command instead of running it.
     """
     r_expression = (
-        'if (!requireNamespace("cffr", quietly = TRUE)) '
-        'stop("Missing required R package: cffr. Install it in workflow setup (e.g. setup-r-dependencies)."); '
+        'for (pkg in c("cffr", "yaml")) { '
+        "  if (!requireNamespace(pkg, quietly = TRUE)) "
+        '    stop("Missing required R package: ", pkg, ". Install it in workflow setup (e.g. setup-r-dependencies).") '
+        "}; "
+        'citation_file <- Sys.getenv("CITATION_FILE"); '
+        "custom_identifiers <- NULL; "
+        "if (file.exists(citation_file)) { "
+        "  tryCatch({ "
+        "    existing_cff <- cffr::cff_read(citation_file); "
+        '    if (!is.null(existing_cff[["identifiers"]])) { '
+        '      custom_identifiers <- existing_cff[["identifiers"]] '
+        "    } "
+        "  }, error = function(e) { }) "
+        "}; "
         'setwd(dirname(Sys.getenv("DESCRIPTION_FILE"))); '
-        'cffr::cff_write(cff_file = Sys.getenv("CITATION_FILE"))'
+        "cffr::cff_write(outfile = citation_file); "
+        "if (!is.null(custom_identifiers)) { "
+        "  yml <- yaml::read_yaml(citation_file); "
+        "  yml$identifiers <- custom_identifiers; "
+        "  yaml::write_yaml(yml, citation_file) "
+        "}"
     )
     citation_filepath_quoted = shlex.quote(str(citation_filepath))
     description_filepath = path_resolve(description_filepath)

--- a/src/ccbr_actions/release.py
+++ b/src/ccbr_actions/release.py
@@ -10,6 +10,7 @@ from ccbr_tools.shell import shell_run
 
 from .actions import set_output, trigger_workflow
 from .citation import update_citation, write_citation
+from .data import get_file_path
 from .util import precommit_run, path_resolve
 from .versions import (
     check_version_increments_by_one,
@@ -103,36 +104,15 @@ def regenerate_citation_from_description(
         description_filepath (str): Path to DESCRIPTION file.
         debug (bool): If True, print command instead of running it.
     """
-    r_expression = (
-        'for (pkg in c("cffr", "yaml")) { '
-        "  if (!requireNamespace(pkg, quietly = TRUE)) "
-        '    stop("Missing required R package: ", pkg, ". Install it in workflow setup (e.g. setup-r-dependencies).") '
-        "}; "
-        'citation_file <- Sys.getenv("CITATION_FILE"); '
-        "custom_identifiers <- NULL; "
-        "if (file.exists(citation_file)) { "
-        "  tryCatch({ "
-        "    existing_cff <- cffr::cff_read(citation_file); "
-        '    if (!is.null(existing_cff[["identifiers"]])) { '
-        '      custom_identifiers <- existing_cff[["identifiers"]] '
-        "    } "
-        "  }, error = function(e) { }) "
-        "}; "
-        'setwd(dirname(Sys.getenv("DESCRIPTION_FILE"))); '
-        "cffr::cff_write(outfile = citation_file); "
-        "if (!is.null(custom_identifiers)) { "
-        "  yml <- yaml::read_yaml(citation_file); "
-        "  yml$identifiers <- custom_identifiers; "
-        "  yaml::write_yaml(yml, citation_file) "
-        "}"
-    )
     citation_filepath_quoted = shlex.quote(str(citation_filepath))
     description_filepath = path_resolve(description_filepath)
     description_filepath_quoted = shlex.quote(str(description_filepath))
+    script_filepath = get_file_path("regenerate_citation_from_description.R")
+    script_filepath_quoted = shlex.quote(str(script_filepath))
     cmd = (
         f"DESCRIPTION_FILE={description_filepath_quoted} "
         f"CITATION_FILE={citation_filepath_quoted} "
-        f"Rscript -e {shlex.quote(r_expression)}"
+        f"Rscript {script_filepath_quoted}"
     )
     if debug:
         print(cmd)

--- a/src/ccbr_actions/release.py
+++ b/src/ccbr_actions/release.py
@@ -10,8 +10,7 @@ from ccbr_tools.shell import shell_run
 
 from .actions import set_output, trigger_workflow
 from .citation import update_citation, write_citation
-from .data import get_file_path
-from .util import precommit_run, path_resolve
+from .util import precommit_run, path_resolve, repo_base
 from .versions import (
     check_version_increments_by_one,
     match_semver,
@@ -107,7 +106,7 @@ def regenerate_citation_from_description(
     citation_filepath_quoted = shlex.quote(str(citation_filepath))
     description_filepath = path_resolve(description_filepath)
     description_filepath_quoted = shlex.quote(str(description_filepath))
-    script_filepath = get_file_path("regenerate_citation_from_description.R")
+    script_filepath = repo_base("data", "regenerate_citation_from_description.R")
     script_filepath_quoted = shlex.quote(str(script_filepath))
     cmd = (
         f"DESCRIPTION_FILE={description_filepath_quoted} "

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -18,6 +18,7 @@ from ccbr_actions.release import (
     set_release_version,
     is_r_package,
 )
+from ccbr_actions.data import get_file_path
 from ccbr_tools.shell import exec_in_context, shell_run
 
 POST_RELEASE_PR_CREATE_COMMAND = (
@@ -295,6 +296,7 @@ def test_write_description_version_updates_field(tmp_path):
 
 
 def test_regenerate_citation_from_description_uses_description_dir(tmp_path):
+    script_path = get_file_path("regenerate_citation_from_description.R")
     output = exec_in_context(
         regenerate_citation_from_description,
         citation_filepath=str(tmp_path / "pkg" / "CITATION.cff"),
@@ -304,7 +306,7 @@ def test_regenerate_citation_from_description_uses_description_dir(tmp_path):
     assert "DESCRIPTION_FILE=" in output
     assert "CITATION_FILE=" in output
     assert str(tmp_path / "pkg" / "DESCRIPTION") in output
-    assert 'setwd(dirname(Sys.getenv("DESCRIPTION_FILE")));' in output
+    assert f"Rscript {script_path}" in output
 
 
 def test_prepare_draft_release_r_package(github_output_file, tmp_path, data_dir):
@@ -344,7 +346,7 @@ def test_prepare_draft_release_r_package(github_output_file, tmp_path, data_dir)
     assert "NEWS.md" in output
     assert "DESCRIPTION" in output
     assert "Version: 0.2.0" in output
-    assert "Rscript -e" in output
+    assert "regenerate_citation_from_description.R" in output
     assert str(description_filepath) in output
 
 
@@ -458,7 +460,9 @@ def test_post_release_cleanup_r_package(github_output_file, tmp_path, monkeypatc
     )
     assert version_line is not None, f"No Version line found in {description_file}"
     assert version_line == "Version: 0.2.0.9000"
-    assert any("Rscript -e" in command for command in commands)
+    assert any(
+        "regenerate_citation_from_description.R" in command for command in commands
+    )
     assert any(
         f"DESCRIPTION_FILE={description_file}" in command for command in commands
     )


### PR DESCRIPTION
## Changes

needed for MOSuite which saves custom fields via auto-format in its citation file

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
