### PR TITLE
fix(build-docker): handle empty suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## actions development version
 
 - New commands `list-rulesets` and `copy-ruleset`, plus a `copy-ruleset` action, for copying GitHub rulesets between repositories. (#183, @kelly-sovacool, @copilot)
+- Fix `build-docker` action: fix bash suffix conditional so an empty suffix (and main) leaves the docker tag unchanged. (#199, @kelly-sovacool)
 
 ## actions 0.7.1
 

--- a/build-docker/README.md
+++ b/build-docker/README.md
@@ -52,6 +52,9 @@ For an advanced example to automatically build docker containers when
 files change, see
 [build-docker-auto.yml](/examples/build-docker-auto.yml).
 
+Suffix behavior: `dev` appends `-dev`, `main` or an empty value leaves
+the Dockerfile tag unchanged, and any other value appends `-feat`.
+
 ## Inputs
 
 - `dockerfile`: path to the Dockerfile in the repo

--- a/build-docker/README.qmd
+++ b/build-docker/README.qmd
@@ -57,6 +57,9 @@ see [build-docker-manual.yml](/examples/build-docker-manual.yml).
 For an advanced example to automatically build docker containers when files
 change, see [build-docker-auto.yml](/examples/build-docker-auto.yml).
 
+Suffix behavior: `dev` appends `-dev`, `main` or an empty value leaves the
+Dockerfile tag unchanged, and any other value appends `-feat`.
+
 
 ```{python}
 print(ccbr_actions.docs.action_markdown_io(action))

--- a/scripts/prepare_docker_build_variables.sh
+++ b/scripts/prepare_docker_build_variables.sh
@@ -50,7 +50,7 @@ baseimagename=$(grep ^FROM $dockerfile | sed "s/FROM //g")
 # Construct the full image name for Docker Hub
 if [[ "$suffix" == "dev" ]]; then
   tag="${tag}-dev"
-elif  [[ "$suffix" == "main" || "suffix" == "" ]]; then
+elif  [[ "$suffix" == "main" || "$suffix" == "" ]]; then
   tag="${tag}"
 else
   tag="${tag}-feat"

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -81,3 +81,19 @@ def test_prepare_docker_build_variables_matches_bash(suffix, tmp_path):
 
     assert py_values == bash_values
     assert py_file_values == bash_values
+
+
+def test_prepare_docker_build_variables_empty_suffix_has_no_extra_suffix(tmp_path):
+    repo_dir = tmp_path / "myrepo"
+    repo_dir.mkdir()
+    dockerfile = repo_dir / "Dockerfile.v2"
+    dockerfile.write_text("FROM ubuntu:22.04\n")
+
+    values = prepare_docker_build_variables(
+        dockerfile=str(dockerfile),
+        suffix="",
+        dockerhub_account="nciccbr",
+    )
+
+    assert values["BUILD_TAG"] == "v2"
+    assert values["IMAGENAME"] == "nciccbr/myrepo:v2"


### PR DESCRIPTION
## Changes

Fix the build-docker action to handle an empty suffix gracefully

## Issues

<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
